### PR TITLE
Fix remaining ruff lints in `__init__` files

### DIFF
--- a/optimum/commands/onnxruntime/__init__.py
+++ b/optimum/commands/onnxruntime/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    "ONNXRuntimeCommand",
+    "ONNXRuntimeOptimizeCommand",
+    "ONNXRuntimeQuantizeCommand",
+]
+
 from .base import ONNXRuntimeCommand
 from .optimize import ONNXRuntimeOptimizeCommand
 from .quantize import ONNXRuntimeQuantizeCommand

--- a/optimum/commands/subpackage/__init__.py
+++ b/optimum/commands/subpackage/__init__.py
@@ -1,1 +1,6 @@
+__all__ = [
+    "ONNXRuntimeCommand",
+]
+
+
 from .commands import ONNXRuntimeCommand

--- a/optimum/commands/subpackage/commands/__init__.py
+++ b/optimum/commands/subpackage/commands/__init__.py
@@ -11,5 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+__all__ = [
+    "ONNXRuntimeCommand",
+]
 
 from .base import ONNXRuntimeCommand

--- a/optimum/exporters/onnx/__init__.py
+++ b/optimum/exporters/onnx/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: F401
+
 from typing import TYPE_CHECKING
 
 from transformers.utils import _LazyModule

--- a/optimum/onnx/__init__.py
+++ b/optimum/onnx/__init__.py
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# ruff: noqa: F401
+
 from typing import TYPE_CHECKING
 
 from transformers.utils import _LazyModule

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# ruff: noqa: F401
+
 from typing import TYPE_CHECKING
 
 from transformers.utils import OptionalDependencyNotAvailable, _LazyModule

--- a/optimum/onnxruntime/preprocessors/__init__.py
+++ b/optimum/onnxruntime/preprocessors/__init__.py
@@ -12,4 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+__all__ = [
+    "PreprocessorPass",
+    "QuantizationPreprocessor",
+]
+
 from .quantization import PreprocessorPass, QuantizationPreprocessor

--- a/optimum/onnxruntime/preprocessors/passes/__init__.py
+++ b/optimum/onnxruntime/preprocessors/passes/__init__.py
@@ -12,6 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+__all__ = [
+    "ExcludeGeLUNodes",
+    "ExcludeLayerNormNodes",
+    "ExcludeNodeAfter",
+    "ExcludeNodeFollowedBy",
+]
+
 from .excluders import ExcludeNodeAfter, ExcludeNodeFollowedBy
 from .gelu import ExcludeGeLUNodes
 from .layernorm import ExcludeLayerNormNodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,10 +120,6 @@ select = [
     "YTT", # flake8-2020
 ]
 
-# Ignore import violations in all `__init__.py` files.
-[tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["E402", "F401", "F403", "F811"]
-
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 known-first-party = ["optimum"]


### PR DESCRIPTION
I used copilot to create `__all__` lists