### PR TITLE
Update documentation

### DIFF
--- a/docs/source/onnx/overview.mdx
+++ b/docs/source/onnx/overview.mdx
@@ -56,6 +56,7 @@ Supported architectures from [🤗 Transformers](https://huggingface.co/docs/tra
 - GPT-Neo
 - GPT-NeoX
 - OPT
+- Granite
 - GroupVit
 - Hiera
 - Hubert

--- a/docs/source/onnx/overview.mdx
+++ b/docs/source/onnx/overview.mdx
@@ -16,6 +16,7 @@ specific language governing permissions and limitations under the License.
 
 Supported architectures from [🤗 Transformers](https://huggingface.co/docs/transformers/index):
 
+- Arcee
 - AST
 - Audio Spectrogram Transformer
 - Albert
@@ -110,6 +111,7 @@ Supported architectures from [🤗 Transformers](https://huggingface.co/docs/tra
 - SEW-D
 - Speech2Text
 - SigLIP
+- SmolLM3
 - SpeechT5
 - Splinter
 - SqueezeBert
@@ -121,6 +123,7 @@ Supported architectures from [🤗 Transformers](https://huggingface.co/docs/tra
 - UniSpeech
 - UniSpeech SAT
 - Vision Encoder Decoder
+- VisualBert
 - Vit
 - VitMAE
 - VitMSN

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1944,9 +1944,11 @@ class ORTModelForFeatureExtractionFromImageModelsIntegrationTest(ORTModelTestMix
     ORTMODEL_CLASS = ORTModelForFeatureExtraction
     TASK = "feature-extraction"
 
-    def get_raw_image(self, model_arch):
-        image_url = "https://picsum.photos/id/237/200/300"
-        return Image.open(requests.get(image_url, stream=True).raw)
+    def get_raw_image(self):  
+        # Create a simple 200x300 RGB image with random colors
+        np.random.seed(42)  # For reproducibility
+        image_array = np.random.randint(0, 256, (300, 200, 3), dtype=np.uint8)
+        return Image.fromarray(image_array)
 
     def get_input(self, model_arch, return_tensors="pt"):
         model_id = MODEL_NAMES[model_arch]
@@ -1977,7 +1979,7 @@ class ORTModelForFeatureExtractionFromImageModelsIntegrationTest(ORTModelTestMix
             )
             return tokens
 
-        raw_input = self.get_raw_image(model_arch)
+        raw_input = self.get_raw_image()
         return processor(images=raw_input, return_tensors=return_tensors)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -1944,7 +1944,7 @@ class ORTModelForFeatureExtractionFromImageModelsIntegrationTest(ORTModelTestMix
     ORTMODEL_CLASS = ORTModelForFeatureExtraction
     TASK = "feature-extraction"
 
-    def get_raw_image(self):  
+    def get_raw_image(self):
         # Create a simple 200x300 RGB image with random colors
         np.random.seed(42)  # For reproducibility
         image_array = np.random.randint(0, 256, (300, 200, 3), dtype=np.uint8)


### PR DESCRIPTION
- Update the documentation for newly supported models (note: adding this initially caused some failing tests due to picsum.photos in `ORTModelForFeatureExtractionFromImageModels`)
- Replace flaky external image downloads with a dummy image to prevent test failures when picsum.photos is unavailable.