### PR TITLE
Use released optimum to avoid pip resolver conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "optimum @ git+https://github.com/huggingface/optimum.git",
+    "optimum",
     "transformers>=4.36,<4.54.0",
     "onnx",
 ]


### PR DESCRIPTION
Luckily optimum-onnx seems to be already compatible with the released version of optimum.