### PR TITLE
Add ort pipelines, their docs and diffusion pipelines docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -7,6 +7,11 @@ on:
       - main
       - doc-builder*
       - v*-release
+      - ort-pipelines
+
+env:
+  UV_SYSTEM_PYTHON: 1
+  UV_TORCH_BACKEND: auto
 
 jobs:
   build_documentation:
@@ -21,13 +26,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
           cache-dependency-path: "kit/package-lock.json"
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Set environment variables
         run: |
@@ -45,20 +50,19 @@ jobs:
 
       - name: Setup environment
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/huggingface/doc-builder
-          python -m pip install .[onnxruntime] accelerate
+          pip install --upgrade pip uv
+          uv pip install .[onnxruntime] accelerate diffusers
+          uv pip install git+https://github.com/huggingface/doc-builder
 
       - name: Make documentation
-        shell: bash
         run: |
-          doc-builder build optimum docs/source/ \
-            --repo_name optimum-onnx \
-            --build_dir onnx-doc-build/ \
-            --version ${{ env.VERSION }} \
-            --version_tag_suffix "" \
-            --html \
-            --clean
+          make doc BUILD_DIR=onnx-doc-build VERSION=${{ env.VERSION }}
+
+      - name: Push documentation
+        run: |
           cd onnx-doc-build
-          mv optimum optimum-onnx
-          doc-builder push optimum-onnx --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.HF_DOC_BUILD_PUSH }}" --commit_msg "Updated with commit $COMMIT_SHA See: https://github.com/huggingface/optimum-onnx/commit/$COMMIT_SHA" --n_retries 5
+          doc-builder push optimum-onnx \
+            --doc_build_repo_id "hf-doc-build/doc-build" \
+            --token "${{ secrets.HF_DOC_BUILD_PUSH }}" \
+            --commit_msg "Updated with commit $COMMIT_SHA See: https://github.com/huggingface/optimum-onnx/commit/$COMMIT_SHA" \
+            --n_retries 5

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -7,7 +7,6 @@ on:
       - main
       - doc-builder*
       - v*-release
-      - ort-pipelines
 
 env:
   UV_SYSTEM_PYTHON: 1
@@ -51,7 +50,7 @@ jobs:
       - name: Setup environment
         run: |
           pip install --upgrade pip uv
-          uv pip install .[onnxruntime] accelerate diffusers
+          uv pip install .[onnxruntime] accelerate diffusers timm
           uv pip install git+https://github.com/huggingface/doc-builder
 
       - name: Make documentation

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  UV_SYSTEM_PYTHON: 1
+  UV_TORCH_BACKEND: auto
+
 jobs:
   build_documentation:
     runs-on: ubuntu-22.04
@@ -22,34 +26,26 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
           cache-dependency-path: "kit/package-lock.json"
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Setup environment
         run: |
-          pip install --upgrade pip
-          pip install git+https://github.com/huggingface/doc-builder
-          pip install .[quality,onnxruntime] accelerate
+          pip install --upgrade pip uv
+          uv pip install .[onnxruntime] accelerate diffusers timm
+          uv pip install git+https://github.com/huggingface/doc-builder
 
       - name: Make documentation
         shell: bash
         run: |
-          doc-builder build optimum docs/source/ \
-            --repo_name optimum-onnx \
-            --build_dir onnx-doc-build/ \
-            --version pr_${{ env.PR_NUMBER }} \
-            --version_tag_suffix "" \
-            --html \
-            --clean
-          cd onnx-doc-build
-          mv optimum optimum-onnx
-          echo ${{ env.COMMIT_SHA }} > ./commit_sha
-          echo ${{ env.PR_NUMBER }} > ./pr_number
+          make doc BUILD_DIR=onnx-doc-build VERSION=pr_${{ env.PR_NUMBER }}
+          echo ${{ env.COMMIT_SHA }} > onnx-doc-build/commit_sha
+          echo ${{ env.PR_NUMBER }} > onnx-doc-build/pr_number
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ doc:
 	doc-builder build optimum docs/source/ \
 	--repo_name optimum-onnx \
 	--build_dir $(BUILD_DIR)/ \
-	--version pr_$(VERSION) \
+	--version $(VERSION) \
 	--version_tag_suffix "" \
 	--html \
 	--clean

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,19 @@ build_dist:
 
 pypi_upload: build_dist
 	python -m twine upload dist/*
+
+# The documentation will be built first in $(BUILD_DIR)/optimum and then moved to
+# $(BUILD_DIR)/optimum-onnx because optimum-onnx extends optimum with both optimum.onnx 
+# and optimum.onnxruntime building directly in $(BUILD_DIR)/optimum-onnx would lead to 
+# issues with relative links in the documentation.
+doc:
+	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)
+	@test -n "$(VERSION)" || (echo "VERSION is empty." ; exit 1)
+	doc-builder build optimum docs/source/ \
+	--repo_name optimum-onnx \
+	--build_dir $(BUILD_DIR)/ \
+	--version pr_${{ env.VERSION }} \
+	--version_tag_suffix "" \
+	--html \
+	--clean
+	mv $(BUILD_DIR)/optimum $(BUILD_DIR)/optimum-onnx

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ doc:
 	doc-builder build optimum docs/source/ \
 	--repo_name optimum-onnx \
 	--build_dir $(BUILD_DIR)/ \
-	--version pr_${{ env.VERSION }} \
+	--version pr_$(VERSION) \
 	--version_tag_suffix "" \
 	--html \
 	--clean

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -33,12 +33,18 @@
     - sections:
       - local: onnxruntime/package_reference/modeling_ort
         title: ONNX Runtime Models
+      - local: onnxruntime/package_reference/modeling_decoder
+        title: ONNX Runtime Decoder Models (LLMs)
+      - local: onnxruntime/package_reference/modeling_diffusion
+        title: ONNX Runtime Diffusion Pipelines
       - local: onnxruntime/package_reference/configuration
         title: Configuration
       - local: onnxruntime/package_reference/optimization
         title: Optimization
       - local: onnxruntime/package_reference/quantization
         title: Quantization
+      - local: onnxruntime/package_reference/pipelines
+        title: Inference pipelines
       title: Reference
       isExpanded: false
     title: ONNX Runtime

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -32,7 +32,9 @@
       isExpanded: false
     - sections:
       - local: onnxruntime/package_reference/modeling_ort
-        title: ONNX Runtime Models
+        title: ONNX Runtime Transformer Models
+      - local: onnxruntime/package_reference/modeling_diffusion
+        title: ONNX Runtime Diffusion Pipelines
       - local: onnxruntime/package_reference/configuration
         title: Configuration
       - local: onnxruntime/package_reference/optimization

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -32,7 +32,9 @@
       isExpanded: false
     - sections:
       - local: onnxruntime/package_reference/modeling_ort
-        title: ONNX Runtime Transformer Models
+        title: ONNX Runtime Models
+      - local: onnxruntime/package_reference/pipelines
+        title: ONNX Runtime Pipelines
       - local: onnxruntime/package_reference/modeling_diffusion
         title: ONNX Runtime Diffusion Pipelines
       - local: onnxruntime/package_reference/configuration

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -33,18 +33,12 @@
     - sections:
       - local: onnxruntime/package_reference/modeling_ort
         title: ONNX Runtime Models
-      - local: onnxruntime/package_reference/modeling_decoder
-        title: ONNX Runtime Decoder Models (LLMs)
-      - local: onnxruntime/package_reference/modeling_diffusion
-        title: ONNX Runtime Diffusion Pipelines
       - local: onnxruntime/package_reference/configuration
         title: Configuration
       - local: onnxruntime/package_reference/optimization
         title: Optimization
       - local: onnxruntime/package_reference/quantization
         title: Quantization
-      - local: onnxruntime/package_reference/pipelines
-        title: Inference pipelines
       title: Reference
       isExpanded: false
     title: ONNX Runtime

--- a/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 
 ## Generic ORT Diffusion Pipeline classes
 
-The following classes are available for instantiating a diffusion pipeline class without needing to specify the architecture.
+The following classes are available for instantiating a diffusion pipeline class without needing to specify the task or architecture.
 
 ### ORTDiffusionPipeline
 
@@ -24,19 +24,18 @@ The following classes are available for instantiating a diffusion pipeline class
 ### ORTPipelineForText2Image
 
 [[autodoc]] onnxruntime.ORTPipelineForText2Image
-    - from_pretrained
 
 ### ORTPipelineForImage2Image
 
 [[autodoc]] onnxruntime.ORTPipelineForImage2Image
-    - from_pretrained
 
 ### ORTPipelineForInpainting
 
 [[autodoc]] onnxruntime.ORTPipelineForInpainting
-    - from_pretrained
 
 ## Supported ORT Diffusion Pipeline classes
+
+The following classes are available for instantiating a diffusion pipeline class for a specific task and architecture.
 
 ### ORTStableDiffusionPipeline
 

--- a/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
@@ -1,0 +1,104 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# ORT Diffusion Pipelines
+
+## Generic ORT Diffusion Pipeline classes
+
+The following classes are available for instantiating a diffusion pipeline class without needing to specify the architecture.
+
+### ORTDiffusionPipeline
+
+[[autodoc]] onnxruntime.ORTDiffusionPipeline
+    - from_pretrained
+
+### ORTPipelineForText2Image
+
+[[autodoc]] onnxruntime.ORTPipelineForText2Image
+    - from_pretrained
+
+### ORTPipelineForImage2Image
+
+[[autodoc]] onnxruntime.ORTPipelineForImage2Image
+    - from_pretrained
+
+### ORTPipelineForInpainting
+
+[[autodoc]] onnxruntime.ORTPipelineForInpainting
+    - from_pretrained
+
+## Supported ORT Diffusion Pipeline classes
+
+### ORTStableDiffusionPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionPipeline
+    - __call__
+
+### ORTStableDiffusionImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionImg2ImgPipeline
+    - __call__
+
+### ORTStableDiffusionInpaintPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionInpaintPipeline
+    - __call__
+
+### ORTStableDiffusionXLPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLPipeline
+    - __call__
+
+### ORTStableDiffusionXLImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
+    - __call__
+
+### ORTStableDiffusionXLInpaintPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLInpaintPipeline
+    - __call__
+
+### ORTStableDiffusionXLImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
+    - __call__
+
+### ORTLatentConsistencyModelPipeline
+
+[[autodoc]] onnxruntime.ORTLatentConsistencyModelPipeline
+    - __call__
+
+### ORTLatentConsistencyModelImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTLatentConsistencyModelImg2ImgPipeline
+    - __call__
+
+### ORTStableDiffusion3Pipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3Pipeline
+    - __call__
+
+### ORTStableDiffusion3Img2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3Img2ImgPipeline
+    - __call__
+
+### ORTStableDiffusion3InpaintPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3InpaintPipeline
+    - __call__
+
+### ORTFluxPipeline
+
+[[autodoc]] onnxruntime.ORTFluxPipeline
+    - __call__

--- a/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_diffusion.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# ORT Diffusion Pipelines
+# ONNX Runtime Diffusion Pipelines
 
 ## Generic ORT Diffusion Pipeline classes
 

--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -32,6 +32,7 @@ The following ORT classes are available for the following natural language proce
 ### ORTModelForMaskedLM
 
 [[autodoc]] onnxruntime.ORTModelForMaskedLM
+    - forward
 
 ### ORTModelForSeq2SeqLM
 
@@ -41,18 +42,22 @@ The following ORT classes are available for the following natural language proce
 ### ORTModelForSequenceClassification
 
 [[autodoc]] onnxruntime.ORTModelForSequenceClassification
+    - forward
 
 ### ORTModelForTokenClassification
 
 [[autodoc]] onnxruntime.ORTModelForTokenClassification
+    - forward
 
 ### ORTModelForMultipleChoice
 
 [[autodoc]] onnxruntime.ORTModelForMultipleChoice
+    - forward
 
 ### ORTModelForQuestionAnswering
 
 [[autodoc]] onnxruntime.ORTModelForQuestionAnswering
+    - forward
 
 ## Computer vision
 
@@ -61,10 +66,12 @@ The following ORT classes are available for the following computer vision tasks.
 ### ORTModelForImageClassification
 
 [[autodoc]] onnxruntime.ORTModelForImageClassification
+    - forward
 
 ### ORTModelForSemanticSegmentation
 
 [[autodoc]] onnxruntime.ORTModelForSemanticSegmentation
+    - forward
 
 ## Audio
 
@@ -73,14 +80,17 @@ The following ORT classes are available for the following audio tasks.
 ### ORTModelForAudioClassification
 
 [[autodoc]] onnxruntime.ORTModelForAudioClassification
+    - forward
 
 ### ORTModelForAudioFrameClassification
 
 [[autodoc]] onnxruntime.ORTModelForAudioFrameClassification
+    - forward
 
 ### ORTModelForCTC
 
 [[autodoc]] onnxruntime.ORTModelForCTC
+    - forward
 
 ### ORTModelForSpeechSeq2Seq
 
@@ -90,6 +100,7 @@ The following ORT classes are available for the following audio tasks.
 ### ORTModelForAudioXVector
 
 [[autodoc]] onnxruntime.ORTModelForAudioXVector
+    - forward
 
 ## Multimodal
 
@@ -116,75 +127,3 @@ The following ORT classes are available for the following custom tasks.
 #### ORTModelForFeatureExtraction
 
 [[autodoc]] onnxruntime.ORTModelForFeatureExtraction
-
-## Diffusion Pipelines
-
-#### ORTDiffusionPipeline
-
-[[autodoc]] onnxruntime.ORTDiffusionPipeline
-    - __call__
-
-#### ORTStableDiffusionPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionPipeline
-    - __call__
-
-#### ORTStableDiffusionImg2ImgPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionImg2ImgPipeline
-    - __call__
-
-#### ORTStableDiffusionInpaintPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionInpaintPipeline
-    - __call__
-
-#### ORTStableDiffusionXLPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionXLPipeline
-    - __call__
-
-#### ORTStableDiffusionXLImg2ImgPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
-    - __call__
-
-#### ORTStableDiffusionXLInpaintPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionXLInpaintPipeline
-    - __call__
-
-#### ORTStableDiffusionXLImg2ImgPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
-    - __call__
-
-#### ORTLatentConsistencyModelPipeline
-
-[[autodoc]] onnxruntime.ORTLatentConsistencyModelPipeline
-    - __call__
-
-#### ORTLatentConsistencyModelImg2ImgPipeline
-
-[[autodoc]] onnxruntime.ORTLatentConsistencyModelImg2ImgPipeline
-    - __call__
-
-#### ORTStableDiffusion3Pipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusion3Pipeline
-    - __call__
-
-#### ORTStableDiffusion3Img2ImgPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusion3Img2ImgPipeline
-    - __call__
-
-#### ORTStableDiffusion3InpaintPipeline
-
-[[autodoc]] onnxruntime.ORTStableDiffusion3InpaintPipeline
-    - __call__
-
-#### ORTFluxPipeline
-
-[[autodoc]] onnxruntime.ORTFluxPipeline
-    - __call__

--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -117,7 +117,7 @@ The following ORT classes are available for the following custom tasks.
 
 [[autodoc]] onnxruntime.ORTModelForFeatureExtraction
 
-## Stable Diffusion
+## Diffusion Pipelines
 
 #### ORTDiffusionPipeline
 

--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -149,7 +149,42 @@ The following ORT classes are available for the following custom tasks.
 [[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
     - __call__
 
+#### ORTStableDiffusionXLInpaintPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLInpaintPipeline
+    - __call__
+
+#### ORTStableDiffusionXLImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusionXLImg2ImgPipeline
+    - __call__
+
 #### ORTLatentConsistencyModelPipeline
 
 [[autodoc]] onnxruntime.ORTLatentConsistencyModelPipeline
+    - __call__
+
+#### ORTLatentConsistencyModelImg2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTLatentConsistencyModelImg2ImgPipeline
+    - __call__
+
+#### ORTStableDiffusion3Pipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3Pipeline
+    - __call__
+
+#### ORTStableDiffusion3Img2ImgPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3Img2ImgPipeline
+    - __call__
+
+#### ORTStableDiffusion3InpaintPipeline
+
+[[autodoc]] onnxruntime.ORTStableDiffusion3InpaintPipeline
+    - __call__
+
+#### ORTFluxPipeline
+
+[[autodoc]] onnxruntime.ORTFluxPipeline
     - __call__

--- a/docs/source/onnxruntime/package_reference/modeling_ort.mdx
+++ b/docs/source/onnxruntime/package_reference/modeling_ort.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Models
+# ONNX Runtime Models
 
 ## Generic model classes
 

--- a/docs/source/onnxruntime/package_reference/pipelines.mdx
+++ b/docs/source/onnxruntime/package_reference/pipelines.mdx
@@ -10,40 +10,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Pipelines
+# ONNX Runtime Pipelines
 
-## Overview
-
-ONNX Runtime pipelines provide a seamless way to use high-performance and cross-platform ONNX exported models with the familiar transformers pipeline interface. 
-This custom implementation automatically loads or exports ONNX Runtime models instead of PyTorch models, delivering significant performance improvements while maintaining the same easy-to-use API.
-
-## What are ONNX Runtime Pipelines?
-
-ONNX Runtime pipelines are a drop-in replacement for [Transformers pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines) that automatically use ONNX/ONNX Runtime as the backend for model inference. 
-This means you get:
-
-- **Faster inference**: ONNX Runtime's optimized execution engine provides significant speedups
-- **Cross-platform support**: Works across different hardware accelerators (CPU, GPU, etc.)
-- **Same API**: Identical interface to transformers pipelines - no code changes needed
-- **Automatic model loading**: Seamlessly loads or exports ONNX models
-
-The pipelines support the same tasks as transformers pipelines, including text classification, token classification, question answering, text generation, and more.
-
-## Usage
-
-Simply import from `optimum.onnxruntime` instead of `transformers`:
-
-```python
-- from transformers import pipeline
-+ from optimum.onnxruntime import pipeline
-
-# This will automatically use ONNX Runtime models
-classifier = pipeline("text-classification", model="distilbert-base-uncased")
-result = classifier("I love using ONNX Runtime!")
-```
-
-For more details on pipeline usage and available tasks, refer to the [Transformers pipelines documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines).
-
-## ONNX Runtime Pipelines
-
-[[autodoc]] onnxruntime.pipelines.pipeline
+[[autodoc]] optimum.onnxruntime.pipelines.pipeline

--- a/docs/source/onnxruntime/package_reference/pipelines.mdx
+++ b/docs/source/onnxruntime/package_reference/pipelines.mdx
@@ -1,0 +1,49 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Pipelines
+
+## Overview
+
+ONNX Runtime pipelines provide a seamless way to use high-performance and cross-platform ONNX exported models with the familiar transformers pipeline interface. 
+This custom implementation automatically loads or exports ONNX Runtime models instead of PyTorch models, delivering significant performance improvements while maintaining the same easy-to-use API.
+
+## What are ONNX Runtime Pipelines?
+
+ONNX Runtime pipelines are a drop-in replacement for [Transformers pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines) that automatically use ONNX/ONNX Runtime as the backend for model inference. 
+This means you get:
+
+- **Faster inference**: ONNX Runtime's optimized execution engine provides significant speedups
+- **Cross-platform support**: Works across different hardware accelerators (CPU, GPU, etc.)
+- **Same API**: Identical interface to transformers pipelines - no code changes needed
+- **Automatic model loading**: Seamlessly loads or exports ONNX models
+
+The pipelines support the same tasks as transformers pipelines, including text classification, token classification, question answering, text generation, and more.
+
+## Usage
+
+Simply import from `optimum.onnxruntime` instead of `transformers`:
+
+```python
+- from transformers import pipeline
++ from optimum.onnxruntime import pipeline
+
+# This will automatically use ONNX Runtime models
+classifier = pipeline("text-classification", model="distilbert-base-uncased")
+result = classifier("I love using ONNX Runtime!")
+```
+
+For more details on pipeline usage and available tasks, refer to the [Transformers pipelines documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines).
+
+## ONNX Runtime Pipelines
+
+[[autodoc]] onnxruntime.pipelines.pipeline

--- a/docs/source/onnxruntime/usage_guides/amdgpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/amdgpu.mdx
@@ -101,7 +101,7 @@ The model can then be used with the common 🤗 Transformers API for inference a
 When using Transformers pipeline, note that the `device` argument should be set to perform pre- and post-processing on GPU, following the example below:
 
 ```python
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")

--- a/docs/source/onnxruntime/usage_guides/amdgpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/amdgpu.mdx
@@ -101,7 +101,7 @@ The model can then be used with the common 🤗 Transformers API for inference a
 When using Transformers pipeline, note that the `device` argument should be set to perform pre- and post-processing on GPU, following the example below:
 
 ```python
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -72,7 +72,7 @@ The model can then be used with the common 🤗 Transformers API for inference a
 When using Transformers pipeline, note that the `device` argument should be set to perform pre- and post-processing on GPU, following the example below:
 
 ```python
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")

--- a/docs/source/onnxruntime/usage_guides/gpu.mdx
+++ b/docs/source/onnxruntime/usage_guides/gpu.mdx
@@ -72,7 +72,7 @@ The model can then be used with the common 🤗 Transformers API for inference a
 When using Transformers pipeline, note that the `device` argument should be set to perform pre- and post-processing on GPU, following the example below:
 
 ```python
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 >>> from transformers import AutoTokenizer
 
 >>> tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")

--- a/docs/source/onnxruntime/usage_guides/models.mdx
+++ b/docs/source/onnxruntime/usage_guides/models.mdx
@@ -26,6 +26,20 @@ Once your model was [exported to the ONNX format](https://huggingface.co/docs/op
 
 More information for all the supported `ORTModelForXxx` in our [documentation](https://huggingface.co/docs/optimum/onnxruntime/package_reference/modeling_ort)
 
+### Transformers pipelines
+
+You can also load your ONNX model using ONNX Runtime pipelines which replace `transformers.pipeline` with `optimum.onnxruntime.pipeline`.
+
+```diff
+- from transformers import pipeline
++ from optimum.onnxruntime import pipeline
+
+  model_id = "distilbert-base-uncased-finetuned-sst-2-english"
+  nlp_pipeline = pipeline("sentiment-analysis", model=model_id)
+  result = nlp_pipeline("I've been waiting for a HuggingFace course my whole life.")
+```
+
+More information for all the supported `ORTXxxPipeline` in our [documentation](https://huggingface.co/docs/optimum/onnxruntime/package_reference/pipelines)
 
 ### Diffusers models
 
@@ -38,7 +52,7 @@ Once your model was [exported to the ONNX format](https://huggingface.co/docs/op
 
   model_id = "runwayml/stable-diffusion-v1-5"
 - pipeline = DiffusionPipeline.from_pretrained(model_id)
-+ pipeline = ORTDiffusionPipeline.from_pretrained(model_id, revision="onnx")
++ pipeline = ORTDiffusionPipeline.from_pretrained(model_id, export=True)
   prompt = "sailing ship in storm by Leonardo da Vinci"
   image = pipeline(prompt).images[0]
 ```

--- a/docs/source/onnxruntime/usage_guides/models.mdx
+++ b/docs/source/onnxruntime/usage_guides/models.mdx
@@ -43,6 +43,8 @@ Once your model was [exported to the ONNX format](https://huggingface.co/docs/op
   image = pipeline(prompt).images[0]
 ```
 
+More information for all the supported `ORTXxxPipeline` in our [documentation](https://huggingface.co/docs/optimum/onnxruntime/package_reference/modeling_diffusion)
+
 
 ### Sentence Transformers models
 

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -34,7 +34,7 @@ The [`~onnxruntime.pipelines.pipeline`] function automatically loads a default m
 1. Start by creating a pipeline by specifying an inference task:
 
 ```python
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> classifier = pipeline(task="text-classification", accelerator="ort")
 ```
@@ -64,7 +64,7 @@ You can check the list of supported architectures [here](https://huggingface.co/
 Once you have picked an appropriate model, you can create the [`~onnxruntime.pipelines.pipeline`] by specifying the model repo:
 
 ```python
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 # The model will be loaded to an ORTModelForQuestionAnswering.
 >>> onnx_qa = pipeline("question-answering", model="deepset/roberta-base-squad2", accelerator="ort")
@@ -82,7 +82,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 ```python
 >>> from transformers import AutoTokenizer
 >>> from optimum.onnxruntime import ORTModelForQuestionAnswering
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> tokenizer = AutoTokenizer.from_pretrained("deepset/roberta-base-squad2")
 
@@ -105,7 +105,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 The [`~onnxruntime.pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
 
 ```python
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> onnx_qa = pipeline("question-answering", model="optimum/roberta-base-squad2", accelerator="ort")
 >>> question = "What's my name?"
@@ -122,7 +122,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 ```python
 >>> from transformers import AutoTokenizer
 >>> from optimum.onnxruntime import ORTModelForQuestionAnswering
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> tokenizer = AutoTokenizer.from_pretrained("optimum/roberta-base-squad2")
 
@@ -154,7 +154,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 ...     ORTModelForSequenceClassification,
 ...     ORTQuantizer
 ... )
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> # Load the tokenizer and export the model to the ONNX format
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"
@@ -194,7 +194,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 ...     ORTOptimizer
 ... )
 >>> from optimum.onnxruntime.configuration import OptimizationConfig
->>> from optimum.onnxruntime.pipelines import pipeline
+>>> from optimum.onnxruntime import pipeline
 
 >>> # Load the tokenizer and export the model to the ONNX format
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -1,56 +1,79 @@
 # Inference pipelines with the ONNX Runtime accelerator
 
-The [`~pipelines.pipeline`] function makes it simple to use models from the [Model Hub](https://huggingface.co/models)
+The [`~optimum.onnxruntime.pipelines.pipeline`] function makes it simple to use models from the [Model Hub](https://huggingface.co/models)
 for accelerated inference on a variety of tasks such as text classification, question answering and image classification.
+
+ONNX Runtime pipelines are a drop-in replacement for [Transformers pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines) that automatically use ONNX/ONNX Runtime as the backend for model inference. 
+This means you get:
+
+- **Faster inference**: ONNX Runtime's optimized execution engine provides significant speedups
+- **Cross-platform support**: Works across different hardware accelerators (CPU, GPU, etc.)
+- **Same API**: Identical interface to transformers pipelines - no code changes needed
+- **Automatic model loading**: Seamlessly loads or exports ONNX models
 
 <Tip>
 
 You can also use the
 [pipeline()](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines#pipelines) function from
-Transformers and provide your Optimum model class.
+Transformers and provide your Optimum model and tokenizer/feature-extractor to it.
+
+```python
+>>> from transformers import pipeline
+>>> from optimum.onnxruntime import ORTModelForSequenceClassification
+>>> from transformers import AutoTokenizer
+>>> model = ORTModelForSequenceClassification.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")
+>>> tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased-finetuned-sst-2-english")
+>>> onnx_pipeline = pipeline("text-classification", model=model, tokenizer=tokenizer)
+>>> onnx_pipeline("I love you")  # doctest: +IGNORE_RESULT
+[{'label': 'POSITIVE', 'score': 0.999870002746582}]
+```
 
 </Tip>
 
 Currently the supported tasks are:
 
-* `feature-extraction`
-* `text-classification`
-* `token-classification`
-* `question-answering`
-* `zero-shot-classification`
-* `text-generation`
-* `text2text-generation`
-* `summarization`
-* `translation`
-* `image-classification`
-* `automatic-speech-recognition`
-* `image-to-text`
+* `audio-classification`: Classify audio inputs into predefined categories.
+* `automatic-speech-recognition`: Convert spoken language into text.
+* `feature-extraction`: Extract features from text or images using pre-trained models.
+* `fill-mask`: Predict missing words in a sentence.
+* `image-classification`: Classify images into predefined categories.
+* `image-segmentation`: Segment images into different regions based on their content.
+* `image-to-image`: Transform images from one domain to another (e.g., style transfer).
+* `image-to-text`: Generate textual descriptions for images.
+* `question-answering`: Answer questions based on a given context.
+* `summarization`: Generate concise summaries of longer text documents.
+* `text2text-generation`: Generate text based on a given input text.
+* `text-classification`: Classify text into predefined categories (e.g., sentiment analysis).
+* `text-generation`: Generate text based on a given prompt.
+* `token-classification`: Classify individual tokens in a text (e.g., named entity recognition).
+* `translation`: Translate text from one language to another.
+* `zero-shot-classification`: Classify text into categories without prior training on those categories.
 
-## Optimum pipeline usage
+## ONNX Runtime pipeline usage
 
-While each task has an associated pipeline class, it is simpler to use the general [`~onnxruntime.pipelines.pipeline`] function which wraps all the task-specific pipelines in one object.
-The [`~onnxruntime.pipelines.pipeline`] function automatically loads a default model and tokenizer/feature-extractor capable of performing inference for your task.
+While each task has an associated pipeline class, it is simpler to use the general [`~optimum.onnxruntime.pipelines.pipeline`] function which wraps all the task-specific pipelines in one object.
+The [`~optimum.onnxruntime.pipelines.pipeline`] function automatically loads a default model and tokenizer/feature-extractor capable of performing inference for your task.
 
 1. Start by creating a pipeline by specifying an inference task:
 
 ```python
 >>> from optimum.onnxruntime import pipeline
 
->>> classifier = pipeline(task="text-classification", accelerator="ort")
+>>> classifier = pipeline(task="text-classification")
 ```
 
-2. Pass your input text/image to the [`~onnxruntime.pipelines.pipeline`] function:
+2. Pass your input text/image to the [`~optimum.onnxruntime.pipelines.pipeline`] function:
 
 ```python
 >>> classifier("I like you. I love you.")  # doctest: +IGNORE_RESULT
 [{'label': 'POSITIVE', 'score': 0.9998838901519775}]
 ```
 
-_Note: The default models used in the [`~onnxruntime.pipelines.pipeline`] function are not optimized for inference or quantized, so there won't be a performance improvement compared to their PyTorch counterparts._
+_Note: The default models used in the [`~optimum.onnxruntime.pipelines.pipeline`] function are not optimized for inference or quantized, so there won't be a performance improvement compared to their PyTorch counterparts._
 
 ### Using vanilla Transformers model and converting to ONNX
 
-The [`~onnxruntime.pipelines.pipeline`] function accepts any supported model from the [Hugging Face Hub](https://huggingface.co/models).
+The [`~optimum.onnxruntime.pipelines.pipeline`] function accepts any supported model from the [Hugging Face Hub](https://huggingface.co/models).
 There are tags on the Model Hub that allow you to filter for a model you'd like to use for your task.
 
 <Tip>
@@ -61,13 +84,13 @@ You can check the list of supported architectures [here](https://huggingface.co/
 
 </Tip>
 
-Once you have picked an appropriate model, you can create the [`~onnxruntime.pipelines.pipeline`] by specifying the model repo:
+Once you have picked an appropriate model, you can create the [`~optimum.onnxruntime.pipelines.pipeline`] by specifying the model repo:
 
 ```python
 >>> from optimum.onnxruntime import pipeline
 
 # The model will be loaded to an ORTModelForQuestionAnswering.
->>> onnx_qa = pipeline("question-answering", model="deepset/roberta-base-squad2", accelerator="ort")
+>>> onnx_qa = pipeline("question-answering", model="deepset/roberta-base-squad2")
 >>> question = "What's my name?"
 >>> context = "My name is Philipp and I live in Nuremberg."
 
@@ -93,7 +116,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 ...     export=True
 ... )
 
->>> onnx_qa = pipeline("question-answering", model=model, tokenizer=tokenizer, accelerator="ort")
+>>> onnx_qa = pipeline("question-answering", model=model, tokenizer=tokenizer)
 >>> question = "What's my name?"
 >>> context = "My name is Philipp and I live in Nuremberg."
 
@@ -102,12 +125,12 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 
 ### Using Optimum models
 
-The [`~onnxruntime.pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
+The [`~optimum.onnxruntime.pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
 
 ```python
 >>> from optimum.onnxruntime import pipeline
 
->>> onnx_qa = pipeline("question-answering", model="optimum/roberta-base-squad2", accelerator="ort")
+>>> onnx_qa = pipeline("question-answering", model="optimum/roberta-base-squad2")
 >>> question = "What's my name?"
 >>> context = "My name is Philipp and I live in Nuremberg."
 
@@ -129,7 +152,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 >>> # Loading directly an ONNX model from a model repo.
 >>> model = ORTModelForQuestionAnswering.from_pretrained("optimum/roberta-base-squad2")
 
->>> onnx_qa = pipeline("question-answering", model=model, tokenizer=tokenizer, accelerator="ort")
+>>> onnx_qa = pipeline("question-answering", model=model, tokenizer=tokenizer)
 >>> question = "What's my name?"
 >>> context = "My name is Philipp and I live in Nuremberg."
 
@@ -139,7 +162,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 
 ## Optimizing and quantizing in pipelines
 
-The [`~onnxruntime.pipelines.pipeline`] function can not only run inference on vanilla ONNX Runtime checkpoints - you can also use
+The [`~optimum.onnxruntime.pipelines.pipeline`] function can not only run inference on vanilla ONNX Runtime checkpoints - you can also use
 checkpoints optimized with the [`~optimum.onnxruntime.ORTQuantizer`] and the [`~optimum.onnxruntime.ORTOptimizer`].
 
 Below you can find two examples of how you could use the [`~optimum.onnxruntime.ORTOptimizer`] and the
@@ -173,7 +196,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 >>> model = ORTModelForSequenceClassification.from_pretrained(save_dir)
 
 >>> # Create the transformers pipeline
->>> onnx_clx = pipeline("text-classification", model=model, accelerator="ort")
+>>> onnx_clx = pipeline("text-classification", model=model)
 >>> text = "I like the new ORT pipeline"
 >>> pred = onnx_clx(text)
 >>> print(pred)  # doctest: +IGNORE_RESULT
@@ -213,7 +236,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 >>> model = ORTModelForSequenceClassification.from_pretrained(save_dir)
 
 # Create the transformers pipeline
->>> onnx_clx = pipeline("text-classification", model=model, accelerator="ort")
+>>> onnx_clx = pipeline("text-classification", model=model)
 >>> text = "I like the new ORT pipeline"
 >>> pred = onnx_clx(text)
 >>> print(pred)  # doctest: +IGNORE_RESULT

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -34,7 +34,7 @@ The [`~pipelines.pipeline`] function automatically loads a default model and tok
 1. Start by creating a pipeline by specifying an inference task:
 
 ```python
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> classifier = pipeline(task="text-classification", accelerator="ort")
 ```
@@ -64,7 +64,7 @@ You can check the list of supported architectures [here](https://huggingface.co/
 Once you have picked an appropriate model, you can create the [`~pipelines.pipeline`] by specifying the model repo:
 
 ```python
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 # The model will be loaded to an ORTModelForQuestionAnswering.
 >>> onnx_qa = pipeline("question-answering", model="deepset/roberta-base-squad2", accelerator="ort")
@@ -82,7 +82,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 ```python
 >>> from transformers import AutoTokenizer
 >>> from optimum.onnxruntime import ORTModelForQuestionAnswering
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> tokenizer = AutoTokenizer.from_pretrained("deepset/roberta-base-squad2")
 
@@ -105,7 +105,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 The [`~pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
 
 ```python
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> onnx_qa = pipeline("question-answering", model="optimum/roberta-base-squad2", accelerator="ort")
 >>> question = "What's my name?"
@@ -122,7 +122,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 ```python
 >>> from transformers import AutoTokenizer
 >>> from optimum.onnxruntime import ORTModelForQuestionAnswering
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> tokenizer = AutoTokenizer.from_pretrained("optimum/roberta-base-squad2")
 
@@ -154,7 +154,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 ...     ORTModelForSequenceClassification,
 ...     ORTQuantizer
 ... )
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> # Load the tokenizer and export the model to the ONNX format
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"
@@ -194,7 +194,7 @@ Below you can find two examples of how you could use the [`~optimum.onnxruntime.
 ...     ORTOptimizer
 ... )
 >>> from optimum.onnxruntime.configuration import OptimizationConfig
->>> from optimum.pipelines import pipeline
+>>> from optimum.onnxruntime.pipelines import pipeline
 
 >>> # Load the tokenizer and export the model to the ONNX format
 >>> model_id = "distilbert-base-uncased-finetuned-sst-2-english"

--- a/docs/source/onnxruntime/usage_guides/pipelines.mdx
+++ b/docs/source/onnxruntime/usage_guides/pipelines.mdx
@@ -28,8 +28,8 @@ Currently the supported tasks are:
 
 ## Optimum pipeline usage
 
-While each task has an associated pipeline class, it is simpler to use the general [`~pipelines.pipeline`] function which wraps all the task-specific pipelines in one object.
-The [`~pipelines.pipeline`] function automatically loads a default model and tokenizer/feature-extractor capable of performing inference for your task.
+While each task has an associated pipeline class, it is simpler to use the general [`~onnxruntime.pipelines.pipeline`] function which wraps all the task-specific pipelines in one object.
+The [`~onnxruntime.pipelines.pipeline`] function automatically loads a default model and tokenizer/feature-extractor capable of performing inference for your task.
 
 1. Start by creating a pipeline by specifying an inference task:
 
@@ -39,18 +39,18 @@ The [`~pipelines.pipeline`] function automatically loads a default model and tok
 >>> classifier = pipeline(task="text-classification", accelerator="ort")
 ```
 
-2. Pass your input text/image to the [`~pipelines.pipeline`] function:
+2. Pass your input text/image to the [`~onnxruntime.pipelines.pipeline`] function:
 
 ```python
 >>> classifier("I like you. I love you.")  # doctest: +IGNORE_RESULT
 [{'label': 'POSITIVE', 'score': 0.9998838901519775}]
 ```
 
-_Note: The default models used in the [`~pipelines.pipeline`] function are not optimized for inference or quantized, so there won't be a performance improvement compared to their PyTorch counterparts._
+_Note: The default models used in the [`~onnxruntime.pipelines.pipeline`] function are not optimized for inference or quantized, so there won't be a performance improvement compared to their PyTorch counterparts._
 
 ### Using vanilla Transformers model and converting to ONNX
 
-The [`~pipelines.pipeline`] function accepts any supported model from the [Hugging Face Hub](https://huggingface.co/models).
+The [`~onnxruntime.pipelines.pipeline`] function accepts any supported model from the [Hugging Face Hub](https://huggingface.co/models).
 There are tags on the Model Hub that allow you to filter for a model you'd like to use for your task.
 
 <Tip>
@@ -61,7 +61,7 @@ You can check the list of supported architectures [here](https://huggingface.co/
 
 </Tip>
 
-Once you have picked an appropriate model, you can create the [`~pipelines.pipeline`] by specifying the model repo:
+Once you have picked an appropriate model, you can create the [`~onnxruntime.pipelines.pipeline`] by specifying the model repo:
 
 ```python
 >>> from optimum.onnxruntime.pipelines import pipeline
@@ -102,7 +102,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 
 ### Using Optimum models
 
-The [`~pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
+The [`~onnxruntime.pipelines.pipeline`] function is tightly integrated with the [Hugging Face Hub](https://huggingface.co/models) and can load ONNX models directly.
 
 ```python
 >>> from optimum.onnxruntime.pipelines import pipeline
@@ -139,7 +139,7 @@ For example, here is how you can load the [`~onnxruntime.ORTModelForQuestionAnsw
 
 ## Optimizing and quantizing in pipelines
 
-The [`~pipelines.pipeline`] function can not only run inference on vanilla ONNX Runtime checkpoints - you can also use
+The [`~onnxruntime.pipelines.pipeline`] function can not only run inference on vanilla ONNX Runtime checkpoints - you can also use
 checkpoints optimized with the [`~optimum.onnxruntime.ORTQuantizer`] and the [`~optimum.onnxruntime.ORTOptimizer`].
 
 Below you can find two examples of how you could use the [`~optimum.onnxruntime.ORTOptimizer`] and the

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -57,6 +57,7 @@ _import_structure = {
     ],
     "modeling_decoder": ["ORTModelForCausalLM"],
     "optimization": ["ORTOptimizer"],
+    "pipelines": ["pipeline"],
     "quantization": ["ORTQuantizer"],
     "utils": [
         "ONNX_DECODER_NAME",
@@ -149,6 +150,7 @@ if TYPE_CHECKING:
         ORTModelForVision2Seq,
     )
     from .optimization import ORTOptimizer
+    from .pipelines import pipeline
     from .quantization import ORTQuantizer
     from .utils import (
         ONNX_DECODER_MERGED_NAME,

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -72,7 +72,7 @@ try:
     if not is_diffusers_available():
         raise OptionalDependencyNotAvailable()  # noqa: TRY301
 except OptionalDependencyNotAvailable:
-    _import_structure[".utils.dummy_diffusers_objects"] = [
+    _import_structure["dummy_objects"] = [
         "ORTDiffusionPipeline",
         "ORTPipelineForText2Image",
         "ORTPipelineForImage2Image",
@@ -163,7 +163,7 @@ if TYPE_CHECKING:
         if not is_diffusers_available():
             raise OptionalDependencyNotAvailable()  # noqa: TRY301
     except OptionalDependencyNotAvailable:
-        from optimum.utils.dummy_diffusers_objects import (
+        from .dummy_objects import (
             # generic entrypoint
             ORTDiffusionPipeline,
             # flux

--- a/optimum/onnxruntime/dummy_objects.py
+++ b/optimum/onnxruntime/dummy_objects.py
@@ -1,0 +1,193 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import ClassVar
+
+from optimum.utils.import_utils import DummyObject, requires_backends
+
+
+class ORTDiffusionPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTPipelineForText2Image(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTPipelineForImage2Image(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTPipelineForInpainting(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionImg2ImgPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionInpaintPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionXLPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionXLImg2ImgPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusionXLInpaintPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTLatentConsistencyModelPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTLatentConsistencyModelImg2ImgPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusion3Pipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusion3Img2ImgPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTStableDiffusion3InpaintPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])
+
+
+class ORTFluxPipeline(metaclass=DummyObject):
+    _backends: ClassVar = ["diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["diffusers"])

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -330,12 +330,17 @@ class ORTDiffusionPipeline(ORTParentMixin, DiffusionPipeline):
         model_save_tmpdir = None
         model_save_path = Path(model_name_or_path)
 
-        # automatic export unpon missing files
+        # automatic export upon missing files
         if export is None:
             if "unet" in config and config["unet"] is not None:
                 relative_file_path = Path(DIFFUSION_MODEL_UNET_SUBFOLDER) / ONNX_WEIGHTS_NAME
             elif "transformer" in config and config["transformer"] is not None:
                 relative_file_path = Path(DIFFUSION_MODEL_TRANSFORMER_SUBFOLDER) / ONNX_WEIGHTS_NAME
+            else:
+                raise ValueError(
+                    "Neither 'unet' nor 'transformer' is present in the pipeline config. "
+                    "Please check your config or set `export=True/False` to bypass automatic export."
+                )
 
             absolute_file_path = model_save_path / relative_file_path
 
@@ -343,7 +348,7 @@ class ORTDiffusionPipeline(ORTParentMixin, DiffusionPipeline):
                 absolute_file_path.is_file()
                 or hf_api.file_exists(
                     repo_id=str(model_name_or_path),
-                    filename=str(absolute_file_path),
+                    filename=str(relative_file_path),
                     revision=hub_kwargs.get("revision"),
                     token=hub_kwargs.get("token"),
                 )

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -844,7 +844,7 @@ ORT_PIPELINE_DOCSTRING = r"""
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
-    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion and corresponding to [diffusers.StableDiffusionPipeline]
+    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion and corresponding to [StableDiffusionPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/text2img#diffusers.StableDiffusionPipeline).
     """
 
@@ -855,7 +855,7 @@ class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg2ImgPipeline):
-    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion and corresponding to [diffusers.StableDiffusionImg2ImgPipeline]
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion and corresponding to [StableDiffusionImg2ImgPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline).
     """
 
@@ -866,7 +866,7 @@ class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInpaintPipeline):
-    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion and corresponding to [diffusers.StableDiffusionInpaintPipeline]
+    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion and corresponding to [StableDiffusionInpaintPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusionInpaintPipeline).
     """
 
@@ -877,7 +877,7 @@ class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInp
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeline):
-    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLPipeline]
+    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion XL and corresponding to [StableDiffusionXLPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLPipeline).
     """
 
@@ -900,7 +900,7 @@ class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeli
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionXLImg2ImgPipeline):
-    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLImg2ImgPipeline]
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion XL and corresponding to [StableDiffusionXLImg2ImgPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLImg2ImgPipeline).
     """
 
@@ -938,7 +938,7 @@ class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionX
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionXLInpaintPipeline):
-    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLInpaintPipeline]
+    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion XL and corresponding to [StableDiffusionXLInpaintPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLInpaintPipeline).
     """
 
@@ -976,7 +976,7 @@ class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionX
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyModelPipeline):
-    """ONNX Runtime-powered Pipeline for text-to-image generation using a Latent Consistency Model and corresponding to [diffusers.LatentConsistencyModelPipeline]
+    """ONNX Runtime-powered Pipeline for text-to-image generation using a Latent Consistency Model and corresponding to [LatentConsistencyModelPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/latent_consistency_models#diffusers.LatentConsistencyModelPipeline).
     """
 
@@ -987,7 +987,7 @@ class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyM
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsistencyModelImg2ImgPipeline):
-    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using a Latent Consistency Model and corresponding to [diffusers.LatentConsistencyModelImg2ImgPipeline]
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using a Latent Consistency Model and corresponding to [LatentConsistencyModelImg2ImgPipeline]
     (https://huggingface.co/docs/diffusers/api/pipelines/latent_consistency_models#diffusers.LatentConsistencyModelImg2ImgPipeline).
     """
 
@@ -1011,7 +1011,7 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Pipeline(ORTDiffusionPipeline, StableDiffusion3Pipeline):
-        """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Pipeline](https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline)."""
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion 3 and corresponding to [StableDiffusion3Pipeline](https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline)."""
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1019,7 +1019,7 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Img2ImgPipeline(ORTDiffusionPipeline, StableDiffusion3Img2ImgPipeline):
-        """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Img2ImgPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion 3 and corresponding to [StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Img2ImgPipeline)."""
 
         task = "image-to-image"
         main_input_name = "image"
@@ -1038,7 +1038,7 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3InpaintPipeline(ORTDiffusionPipeline, StableDiffusion3InpaintPipeline):
-        """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3InpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3InpaintPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion 3 and corresponding to [StableDiffusion3InpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3InpaintPipeline)."""
 
         task = "inpainting"
         main_input_name = "prompt"
@@ -1046,7 +1046,7 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTFluxPipeline(ORTDiffusionPipeline, FluxPipeline):
-        """ONNX Runtime-powered Pipeline for text-to-image generation using Flux and corresponding to [diffusers.FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux#diffusers.FluxPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Flux and corresponding to [FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux#diffusers.FluxPipeline)."""
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1191,7 +1191,7 @@ GENERIC_ORT_PIPELINES = [
 # Documentation updates
 for ort_pipeline_class in SUPPORTED_ORT_PIPELINES:
     if callable(ort_pipeline_class) and ort_pipeline_class.__call__.__doc__ is not None:
-        # change import diffusers classes to optimum.onnxruntime classes in docstring
+        # change from diffusers import {}Pipeline to from optimum.onnxruntime import ORT{}Pipeline
         ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
             f"from diffusers import {ort_pipeline_class.auto_model_class.__name__}",
             f"from optimum.onnxruntime import {ort_pipeline_class.__name__}",
@@ -1203,12 +1203,19 @@ for ort_pipeline_class in SUPPORTED_ORT_PIPELINES:
                     f"from optimum.onnxruntime import {generic_ort_pipeline_class.__name__}",
                 )
 
-        # change specific class name in docstring
+        # change {}.from_pretrained to ORT{}.from_pretrained
         ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
-            ort_pipeline_class.auto_model_class.__name__, ort_pipeline_class.__name__
+            f"{ort_pipeline_class.auto_model_class.__name__}.from_pretrained",
+            f"{ort_pipeline_class.__name__}.from_pretrained",
         )
         for generic_ort_pipeline_class in GENERIC_ORT_PIPELINES:
             if generic_ort_pipeline_class != ort_pipeline_class:
                 ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
-                    generic_ort_pipeline_class.auto_model_class.__name__, generic_ort_pipeline_class.__name__
+                    f"{generic_ort_pipeline_class.auto_model_class.__name__}.from_pretrained",
+                    f"{generic_ort_pipeline_class.__name__}.from_pretrained",
                 )
+
+        # change ~pipelines.{}.{}Output to diffusers.pipelines.{}.{}Output
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            "~pipelines.", "diffusers.pipelines."
+        )

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -838,13 +838,15 @@ class ORTVae(ORTParentMixin):
 
 ORT_PIPELINE_DOCSTRING = r"""
     This Pipeline inherits from [`ORTDiffusionPipeline`] and is used to run inference with the ONNX Runtime.
-    The pipeline can be loaded from a pretrained pipeline using the [`ORTDiffusionPipeline.from_pretrained`] method.
+    The pipeline can be loaded from a pretrained pipeline using the generic [`ORTDiffusionPipeline.from_pretrained`] method.
 """
 
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/text2img#diffusers.StableDiffusionPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion and corresponding to [diffusers.StableDiffusionPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/text2img#diffusers.StableDiffusionPipeline).
+    """
 
     task = "text-to-image"
     main_input_name = "prompt"
@@ -853,7 +855,9 @@ class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg2ImgPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion and corresponding to [diffusers.StableDiffusionImg2ImgPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline).
+    """
 
     task = "image-to-image"
     main_input_name = "image"
@@ -862,7 +866,9 @@ class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInpaintPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusionInpaintPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion and corresponding to [diffusers.StableDiffusionInpaintPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusionInpaintPipeline).
+    """
 
     task = "inpainting"
     main_input_name = "prompt"
@@ -871,7 +877,9 @@ class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInp
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionXLPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLPipeline).
+    """
 
     task = "text-to-image"
     main_input_name = "prompt"
@@ -892,7 +900,9 @@ class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeli
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionXLImg2ImgPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionXLImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLImg2ImgPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLImg2ImgPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLImg2ImgPipeline).
+    """
 
     task = "image-to-image"
     main_input_name = "prompt"
@@ -928,7 +938,9 @@ class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionX
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionXLInpaintPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionXLInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLInpaintPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion XL and corresponding to [diffusers.StableDiffusionXLInpaintPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLInpaintPipeline).
+    """
 
     main_input_name = "image"
     task = "inpainting"
@@ -964,7 +976,9 @@ class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionX
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyModelPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency#diffusers.LatentConsistencyModelPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-to-image generation using a Latent Consistency Model and corresponding to [diffusers.LatentConsistencyModelPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/latent_consistency_models#diffusers.LatentConsistencyModelPipeline).
+    """
 
     task = "text-to-image"
     main_input_name = "prompt"
@@ -973,7 +987,9 @@ class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyM
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsistencyModelImg2ImgPipeline):
-    """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency_img2img#diffusers.LatentConsistencyModelImg2ImgPipeline)."""
+    """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using a Latent Consistency Model and corresponding to [diffusers.LatentConsistencyModelImg2ImgPipeline]
+    (https://huggingface.co/docs/diffusers/api/pipelines/latent_consistency_models#diffusers.LatentConsistencyModelImg2ImgPipeline).
+    """
 
     task = "image-to-image"
     main_input_name = "image"
@@ -995,7 +1011,9 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Pipeline(ORTDiffusionPipeline, StableDiffusion3Pipeline):
-        """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusion3Pipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/text2img#diffusers.StableDiffusion3Pipeline)."""
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Pipeline]
+        (https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline).
+        """
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1003,7 +1021,9 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Img2ImgPipeline(ORTDiffusionPipeline, StableDiffusion3Img2ImgPipeline):
-        """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusion3Img2ImgPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Img2ImgPipeline]
+        (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Img2ImgPipeline).
+        """
 
         task = "image-to-image"
         main_input_name = "image"
@@ -1022,7 +1042,9 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3InpaintPipeline(ORTDiffusionPipeline, StableDiffusion3InpaintPipeline):
-        """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusion3InpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusion3InpaintPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3InpaintPipeline]
+        (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3InpaintPipeline).
+        """
 
         task = "inpainting"
         main_input_name = "prompt"
@@ -1030,7 +1052,9 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTFluxPipeline(ORTDiffusionPipeline, FluxPipeline):
-        """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux/text2img#diffusers.FluxPipeline)."""
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Flux and corresponding to [diffusers.FluxPipeline]
+        (https://huggingface.co/docs/diffusers/api/pipelines/flux#diffusers.FluxPipeline).
+        """
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1058,6 +1082,22 @@ SUPPORTED_ORT_PIPELINES = [
     ORTStableDiffusion3InpaintPipeline,
     ORTFluxPipeline,
 ]
+
+for ort_pipeline_class in SUPPORTED_ORT_PIPELINES:
+    if callable(ort_pipeline_class) and ort_pipeline_class.__call__.__doc__ is not None:
+        # change specific class name in docstring
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            ort_pipeline_class.auto_model_class.__name__, ort_pipeline_class.__name__
+        )
+        # change generic/entrypoint class name in docstring
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            "DiffusionPipeline", "ORTDiffusionPipeline"
+        )
+        # change import diffusers to optimum.onnxruntime in docstring
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            f"from diffusers import {ort_pipeline_class.auto_model_class.__name__}",
+            f"from optimum.onnxruntime import {ort_pipeline_class.__name__}",
+        )
 
 
 def _get_ort_class(pipeline_class_name: str, throw_error_if_not_exist: bool = True):

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -54,11 +54,7 @@ from transformers.utils import http_user_agent
 from onnxruntime import InferenceSession, SessionOptions
 from optimum.exporters.onnx import main_export
 from optimum.onnxruntime.base import ORTParentMixin, ORTSessionMixin
-from optimum.onnxruntime.utils import (
-    get_device_for_provider,
-    np_to_pt_generators,
-    prepare_providers_and_provider_options,
-)
+from optimum.onnxruntime.utils import get_device_for_provider, prepare_providers_and_provider_options
 from optimum.utils import (
     DIFFUSION_MODEL_TEXT_ENCODER_2_SUBFOLDER,
     DIFFUSION_MODEL_TEXT_ENCODER_3_SUBFOLDER,
@@ -491,29 +487,6 @@ class ORTDiffusionPipeline(ORTParentMixin, DiffusionPipeline):
                 commit_message=commit_message,
             )
 
-    def __call__(self, *args, **kwargs):
-        # we do this to keep numpy random states support for now
-
-        args = list(args)
-        for i in range(len(args)):
-            new_args = np_to_pt_generators(args[i], self.device)
-            if args[i] is not new_args:
-                logger.warning(
-                    "Converting numpy random state to torch generator is deprecated. "
-                    "Please pass a torch generator directly to the pipeline."
-                )
-
-        for key, value in kwargs.items():
-            new_value = np_to_pt_generators(value, self.device)
-            if value is not new_value:
-                logger.warning(
-                    "Converting numpy random state to torch generator is deprecated. "
-                    "Please pass a torch generator directly to the pipeline."
-                )
-                kwargs[key] = new_value
-
-        return self.auto_model_class.__call__(self, *args, **kwargs)
-
 
 class ORTModelMixin(ORTSessionMixin, ConfigMixin):
     config_name: str = CONFIG_NAME
@@ -868,9 +841,6 @@ class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
     auto_model_class = StableDiffusionPipeline
 
 
-ORTStableDiffusionPipeline.__call__.__doc__ = StableDiffusionPipeline.__call__.__doc__
-
-
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg2ImgPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline)."""
@@ -880,9 +850,6 @@ class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg
     auto_model_class = StableDiffusionImg2ImgPipeline
 
 
-ORTStableDiffusionImg2ImgPipeline.__call__.__doc__ = StableDiffusionImg2ImgPipeline.__call__.__doc__
-
-
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInpaintPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusionInpaintPipeline)."""
@@ -890,9 +857,6 @@ class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInp
     task = "inpainting"
     main_input_name = "prompt"
     auto_model_class = StableDiffusionInpaintPipeline
-
-
-ORTStableDiffusionInpaintPipeline.__call__.__doc__ = StableDiffusionInpaintPipeline.__call__.__doc__
 
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
@@ -914,9 +878,6 @@ class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeli
         add_time_ids = list(original_size + crops_coords_top_left + target_size)
         add_time_ids = torch.tensor([add_time_ids], dtype=dtype)
         return add_time_ids
-
-
-ORTStableDiffusionXLPipeline.__call__.__doc__ = StableDiffusionXLPipeline.__call__.__doc__
 
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
@@ -955,9 +916,6 @@ class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionX
         return add_time_ids, add_neg_time_ids
 
 
-ORTStableDiffusionXLImg2ImgPipeline.__call__.__doc__ = StableDiffusionXLImg2ImgPipeline.__call__.__doc__
-
-
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionXLInpaintPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionXLInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLInpaintPipeline)."""
@@ -994,9 +952,6 @@ class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionX
         return add_time_ids, add_neg_time_ids
 
 
-ORTStableDiffusionXLInpaintPipeline.__call__.__doc__ = StableDiffusionXLInpaintPipeline.__call__.__doc__
-
-
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyModelPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency#diffusers.LatentConsistencyModelPipeline)."""
@@ -1006,9 +961,6 @@ class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyM
     auto_model_class = LatentConsistencyModelPipeline
 
 
-ORTLatentConsistencyModelPipeline.__call__.__doc__ = LatentConsistencyModelPipeline.__call__.__doc__
-
-
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsistencyModelImg2ImgPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency_img2img#diffusers.LatentConsistencyModelImg2ImgPipeline)."""
@@ -1016,9 +968,6 @@ class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsi
     task = "image-to-image"
     main_input_name = "image"
     auto_model_class = LatentConsistencyModelImg2ImgPipeline
-
-
-ORTLatentConsistencyModelImg2ImgPipeline.__call__.__doc__ = LatentConsistencyModelImg2ImgPipeline.__call__.__doc__
 
 
 class ORTUnavailablePipeline:
@@ -1042,8 +991,6 @@ if is_diffusers_version(">=", "0.29.0"):
         main_input_name = "prompt"
         auto_model_class = StableDiffusion3Pipeline
 
-    ORTStableDiffusion3Pipeline.__call__.__doc__ = StableDiffusion3Pipeline.__call__.__doc__
-
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Img2ImgPipeline(ORTDiffusionPipeline, StableDiffusion3Img2ImgPipeline):
         """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusion3Img2ImgPipeline)."""
@@ -1051,8 +998,6 @@ if is_diffusers_version(">=", "0.29.0"):
         task = "image-to-image"
         main_input_name = "image"
         auto_model_class = StableDiffusion3Img2ImgPipeline
-
-    ORTStableDiffusion3Img2ImgPipeline.__call__.__doc__ = StableDiffusion3Img2ImgPipeline.__call__.__doc__
 else:
 
     class ORTStableDiffusion3Pipeline(ORTUnavailablePipeline):
@@ -1073,8 +1018,6 @@ if is_diffusers_version(">=", "0.30.0"):
         main_input_name = "prompt"
         auto_model_class = StableDiffusion3InpaintPipeline
 
-    ORTStableDiffusion3InpaintPipeline.__call__.__doc__ = StableDiffusion3InpaintPipeline.__call__.__doc__
-
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTFluxPipeline(ORTDiffusionPipeline, FluxPipeline):
         """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux/text2img#diffusers.FluxPipeline)."""
@@ -1082,8 +1025,6 @@ if is_diffusers_version(">=", "0.30.0"):
         task = "text-to-image"
         main_input_name = "prompt"
         auto_model_class = FluxPipeline
-
-    ORTFluxPipeline.__call__.__doc__ = FluxPipeline.__call__.__doc__
 else:
 
     class ORTStableDiffusion3InpaintPipeline(ORTUnavailablePipeline):

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -1011,9 +1011,7 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Pipeline(ORTDiffusionPipeline, StableDiffusion3Pipeline):
-        """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Pipeline]
-        (https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline).
-        """
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Pipeline](https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline)."""
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1021,9 +1019,7 @@ if is_diffusers_version(">=", "0.29.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Img2ImgPipeline(ORTDiffusionPipeline, StableDiffusion3Img2ImgPipeline):
-        """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Img2ImgPipeline]
-        (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Img2ImgPipeline).
-        """
+        """ONNX Runtime-powered Pipeline for text-guided image-to-image generation using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Img2ImgPipeline)."""
 
         task = "image-to-image"
         main_input_name = "image"
@@ -1042,9 +1038,7 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3InpaintPipeline(ORTDiffusionPipeline, StableDiffusion3InpaintPipeline):
-        """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3InpaintPipeline]
-        (https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3InpaintPipeline).
-        """
+        """ONNX Runtime-powered Pipeline for text-guided image inpainting using Stable Diffusion 3 and corresponding to [diffusers.StableDiffusion3InpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3InpaintPipeline)."""
 
         task = "inpainting"
         main_input_name = "prompt"
@@ -1052,9 +1046,7 @@ if is_diffusers_version(">=", "0.30.0"):
 
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTFluxPipeline(ORTDiffusionPipeline, FluxPipeline):
-        """ONNX Runtime-powered Pipeline for text-to-image generation using Flux and corresponding to [diffusers.FluxPipeline]
-        (https://huggingface.co/docs/diffusers/api/pipelines/flux#diffusers.FluxPipeline).
-        """
+        """ONNX Runtime-powered Pipeline for text-to-image generation using Flux and corresponding to [diffusers.FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux#diffusers.FluxPipeline)."""
 
         task = "text-to-image"
         main_input_name = "prompt"
@@ -1082,22 +1074,6 @@ SUPPORTED_ORT_PIPELINES = [
     ORTStableDiffusion3InpaintPipeline,
     ORTFluxPipeline,
 ]
-
-for ort_pipeline_class in SUPPORTED_ORT_PIPELINES:
-    if callable(ort_pipeline_class) and ort_pipeline_class.__call__.__doc__ is not None:
-        # change specific class name in docstring
-        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
-            ort_pipeline_class.auto_model_class.__name__, ort_pipeline_class.__name__
-        )
-        # change generic/entrypoint class name in docstring
-        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
-            "DiffusionPipeline", "ORTDiffusionPipeline"
-        )
-        # change import diffusers to optimum.onnxruntime in docstring
-        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
-            f"from diffusers import {ort_pipeline_class.auto_model_class.__name__}",
-            f"from optimum.onnxruntime import {ort_pipeline_class.__name__}",
-        )
 
 
 def _get_ort_class(pipeline_class_name: str, throw_error_if_not_exist: bool = True):
@@ -1203,3 +1179,36 @@ class ORTPipelineForImage2Image(ORTPipelineForTask):
 class ORTPipelineForInpainting(ORTPipelineForTask):
     auto_model_class = AutoPipelineForInpainting
     ort_pipelines_mapping = ORT_INPAINT_PIPELINES_MAPPING
+
+
+GENERIC_ORT_PIPELINES = [
+    ORTDiffusionPipeline,
+    ORTPipelineForText2Image,
+    ORTPipelineForImage2Image,
+    ORTPipelineForInpainting,
+]
+
+# Documentation updates
+for ort_pipeline_class in SUPPORTED_ORT_PIPELINES:
+    if callable(ort_pipeline_class) and ort_pipeline_class.__call__.__doc__ is not None:
+        # change import diffusers classes to optimum.onnxruntime classes in docstring
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            f"from diffusers import {ort_pipeline_class.auto_model_class.__name__}",
+            f"from optimum.onnxruntime import {ort_pipeline_class.__name__}",
+        )
+        for generic_ort_pipeline_class in GENERIC_ORT_PIPELINES:
+            if generic_ort_pipeline_class != ort_pipeline_class:
+                ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+                    f"from diffusers import {generic_ort_pipeline_class.auto_model_class.__name__}",
+                    f"from optimum.onnxruntime import {generic_ort_pipeline_class.__name__}",
+                )
+
+        # change specific class name in docstring
+        ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+            ort_pipeline_class.auto_model_class.__name__, ort_pipeline_class.__name__
+        )
+        for generic_ort_pipeline_class in GENERIC_ORT_PIPELINES:
+            if generic_ort_pipeline_class != ort_pipeline_class:
+                ort_pipeline_class.__call__.__doc__ = ort_pipeline_class.__call__.__doc__.replace(
+                    generic_ort_pipeline_class.auto_model_class.__name__, generic_ort_pipeline_class.__name__
+                )

--- a/optimum/onnxruntime/modeling_diffusion.py
+++ b/optimum/onnxruntime/modeling_diffusion.py
@@ -868,6 +868,9 @@ class ORTStableDiffusionPipeline(ORTDiffusionPipeline, StableDiffusionPipeline):
     auto_model_class = StableDiffusionPipeline
 
 
+ORTStableDiffusionPipeline.__call__.__doc__ = StableDiffusionPipeline.__call__.__doc__
+
+
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg2ImgPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusionImg2ImgPipeline)."""
@@ -877,6 +880,9 @@ class ORTStableDiffusionImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionImg
     auto_model_class = StableDiffusionImg2ImgPipeline
 
 
+ORTStableDiffusionImg2ImgPipeline.__call__.__doc__ = StableDiffusionImg2ImgPipeline.__call__.__doc__
+
+
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInpaintPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint#diffusers.StableDiffusionInpaintPipeline)."""
@@ -884,6 +890,9 @@ class ORTStableDiffusionInpaintPipeline(ORTDiffusionPipeline, StableDiffusionInp
     task = "inpainting"
     main_input_name = "prompt"
     auto_model_class = StableDiffusionInpaintPipeline
+
+
+ORTStableDiffusionInpaintPipeline.__call__.__doc__ = StableDiffusionInpaintPipeline.__call__.__doc__
 
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
@@ -903,9 +912,11 @@ class ORTStableDiffusionXLPipeline(ORTDiffusionPipeline, StableDiffusionXLPipeli
         text_encoder_projection_dim=None,
     ):
         add_time_ids = list(original_size + crops_coords_top_left + target_size)
-
         add_time_ids = torch.tensor([add_time_ids], dtype=dtype)
         return add_time_ids
+
+
+ORTStableDiffusionXLPipeline.__call__.__doc__ = StableDiffusionXLPipeline.__call__.__doc__
 
 
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
@@ -944,6 +955,9 @@ class ORTStableDiffusionXLImg2ImgPipeline(ORTDiffusionPipeline, StableDiffusionX
         return add_time_ids, add_neg_time_ids
 
 
+ORTStableDiffusionXLImg2ImgPipeline.__call__.__doc__ = StableDiffusionXLImg2ImgPipeline.__call__.__doc__
+
+
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionXLInpaintPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusionXLInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLInpaintPipeline)."""
@@ -980,6 +994,9 @@ class ORTStableDiffusionXLInpaintPipeline(ORTDiffusionPipeline, StableDiffusionX
         return add_time_ids, add_neg_time_ids
 
 
+ORTStableDiffusionXLInpaintPipeline.__call__.__doc__ = StableDiffusionXLInpaintPipeline.__call__.__doc__
+
+
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyModelPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency#diffusers.LatentConsistencyModelPipeline)."""
@@ -989,6 +1006,9 @@ class ORTLatentConsistencyModelPipeline(ORTDiffusionPipeline, LatentConsistencyM
     auto_model_class = LatentConsistencyModelPipeline
 
 
+ORTLatentConsistencyModelPipeline.__call__.__doc__ = LatentConsistencyModelPipeline.__call__.__doc__
+
+
 @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
 class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsistencyModelImg2ImgPipeline):
     """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.LatentConsistencyModelImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/latent_consistency_img2img#diffusers.LatentConsistencyModelImg2ImgPipeline)."""
@@ -996,6 +1016,9 @@ class ORTLatentConsistencyModelImg2ImgPipeline(ORTDiffusionPipeline, LatentConsi
     task = "image-to-image"
     main_input_name = "image"
     auto_model_class = LatentConsistencyModelImg2ImgPipeline
+
+
+ORTLatentConsistencyModelImg2ImgPipeline.__call__.__doc__ = LatentConsistencyModelImg2ImgPipeline.__call__.__doc__
 
 
 class ORTUnavailablePipeline:
@@ -1019,6 +1042,8 @@ if is_diffusers_version(">=", "0.29.0"):
         main_input_name = "prompt"
         auto_model_class = StableDiffusion3Pipeline
 
+    ORTStableDiffusion3Pipeline.__call__.__doc__ = StableDiffusion3Pipeline.__call__.__doc__
+
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTStableDiffusion3Img2ImgPipeline(ORTDiffusionPipeline, StableDiffusion3Img2ImgPipeline):
         """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.StableDiffusion3Img2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img#diffusers.StableDiffusion3Img2ImgPipeline)."""
@@ -1027,6 +1052,7 @@ if is_diffusers_version(">=", "0.29.0"):
         main_input_name = "image"
         auto_model_class = StableDiffusion3Img2ImgPipeline
 
+    ORTStableDiffusion3Img2ImgPipeline.__call__.__doc__ = StableDiffusion3Img2ImgPipeline.__call__.__doc__
 else:
 
     class ORTStableDiffusion3Pipeline(ORTUnavailablePipeline):
@@ -1047,6 +1073,8 @@ if is_diffusers_version(">=", "0.30.0"):
         main_input_name = "prompt"
         auto_model_class = StableDiffusion3InpaintPipeline
 
+    ORTStableDiffusion3InpaintPipeline.__call__.__doc__ = StableDiffusion3InpaintPipeline.__call__.__doc__
+
     @add_end_docstrings(ORT_PIPELINE_DOCSTRING)
     class ORTFluxPipeline(ORTDiffusionPipeline, FluxPipeline):
         """ONNX Runtime-powered stable diffusion pipeline corresponding to [diffusers.FluxPipeline](https://huggingface.co/docs/diffusers/api/pipelines/flux/text2img#diffusers.FluxPipeline)."""
@@ -1055,6 +1083,7 @@ if is_diffusers_version(">=", "0.30.0"):
         main_input_name = "prompt"
         auto_model_class = FluxPipeline
 
+    ORTFluxPipeline.__call__.__doc__ = FluxPipeline.__call__.__doc__
 else:
 
     class ORTStableDiffusion3InpaintPipeline(ORTUnavailablePipeline):

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -113,10 +113,10 @@ def ort_infer_framework_load_model(
 ):
     if isinstance(model, str):
         model_kwargs.pop("framework", None)
-        model_kwargs.pop("model_class", None)
         model_kwargs.pop("accelerator", None)
         model_kwargs.pop("torch_dtype", None)  # not supported for ORTModel
         model_kwargs.pop("_commit_hash", None)  # not supported for ORTModel
+        model_kwargs.pop("model_classes", None)
         ort_model_class = get_ort_model_class(task, config, model, **model_kwargs)
         ort_model = ort_model_class.from_pretrained(model, **model_kwargs)
     elif isinstance(model, ORTModel):

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -126,7 +126,7 @@ def ort_infer_framework_load_model(
     else:
         raise TypeError(
             f"""Model {model} is not supported. Please provide a valid model either as string or ORTModel.
-            You can also provide non model then a default one will be used"""
+            You can also provide None as the model to use a default one."""
         )
 
     return "pt", ort_model

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -335,7 +335,7 @@ def pipeline(  # noqa: D417
     """
     if kwargs.pop("accelerator", None) is not None:
         logger.warning(
-            "The `accelerator` argument should not be passed when using `optimum.onnxruntime.pipelines.pipeline`"
+            "The `accelerator` argument should not be passed when using `optimum.optimum.onnxruntime.pipelines.pipeline`"
             " as ONNX Runtime is the only supported backend. Please remove the `accelerator` argument."
         )
 

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -333,7 +333,7 @@ def pipeline(  # noqa: D417
     >>> recognizer = pipeline("ner", model=model, tokenizer=tokenizer)
     ```
     """
-    if kwargs.get("accelerator") is not None:
+    if kwargs.pop("accelerator", None) is not None:
         logger.warning(
             "The `accelerator` argument should not be passed when using `optimum.onnxruntime.pipelines.pipeline`"
             " as ONNX Runtime is the only supported backend. Please remove the `accelerator` argument."

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -24,6 +24,7 @@ from transformers import AutoConfig, Pipeline
 from transformers import pipeline as transformers_pipeline
 
 from optimum.utils import is_onnxruntime_available, is_transformers_version
+from optimum.utils.logging import get_logger
 
 
 if TYPE_CHECKING:
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
         ProcessorMixin,
     )
 
+
+logger = get_logger(__name__)
 
 if is_onnxruntime_available():
     from optimum.onnxruntime import (
@@ -113,7 +116,6 @@ def ort_infer_framework_load_model(
 ):
     if isinstance(model, str):
         model_kwargs.pop("framework", None)
-        model_kwargs.pop("accelerator", None)
         model_kwargs.pop("torch_dtype", None)  # not supported for ORTModel
         model_kwargs.pop("_commit_hash", None)  # not supported for ORTModel
         model_kwargs.pop("model_classes", None)
@@ -331,6 +333,12 @@ def pipeline(  # noqa: D417
     >>> recognizer = pipeline("ner", model=model, tokenizer=tokenizer)
     ```
     """
+    if kwargs.get("accelerator") is not None:
+        logger.warning(
+            "The `accelerator` argument should not be passed when using `optimum.onnxruntime.pipelines.pipeline`"
+            " as ONNX Runtime is the only supported backend. Please remove the `accelerator` argument."
+        )
+
     version_dependent_kwargs = {}
     if is_transformers_version(">=", "4.46.0"):
         # processor argument was added in transformers v4.46.0

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 """Pipelines running different backends."""
 
+from __future__ import annotations
+
 import contextlib
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import torch
 import transformers.pipelines
@@ -77,7 +79,7 @@ else:
 
 
 def get_ort_model_class(
-    task: str, config: Optional["PretrainedConfig"] = None, model_id: Optional[str] = None, **model_kwargs
+    task: str, config: PretrainedConfig | None = None, model_id: str | None = None, **model_kwargs
 ):
     if task.startswith("translation_"):
         # the pipeline registery takes care of getting the right model id for translation_xx_to_yy
@@ -109,10 +111,10 @@ def get_ort_model_class(
 # a modified transformers.pipelines.base.infer_framework_load_model that loads ORT models
 def ort_infer_framework_load_model(
     model,
-    config: Optional["PretrainedConfig"] = None,
-    model_classes: Optional[dict[str, tuple[type]]] = None,
-    task: Optional[str] = None,
-    framework: Optional[str] = None,
+    config: PretrainedConfig | None = None,
+    model_classes: dict[str, tuple[type]] | None = None,
+    task: str | None = None,
+    framework: str | None = None,
     **model_kwargs,
 ):
     if isinstance(model, str):
@@ -145,23 +147,23 @@ def patch_pipelines_to_load_ort_model():
 # The docstring is simply a copy of transformers.pipelines.pipeline's doc with minor modifications
 # to reflect the fact that this pipeline loads ONNX Runtime models that inherit from ORTModel
 def pipeline(  # noqa: D417
-    task: Optional[str] = None,
-    model: Optional[Union[str, "ORTModel"]] = None,
-    config: Optional[Union[str, "PretrainedConfig"]] = None,
-    tokenizer: Optional[Union[str, "PreTrainedTokenizer", "PreTrainedTokenizerFast"]] = None,
-    feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,
-    image_processor: Optional[Union[str, "BaseImageProcessor"]] = None,
-    processor: Optional[Union[str, "ProcessorMixin"]] = None,
+    task: str | None = None,
+    model: str | ORTModel | None = None,
+    config: str | PretrainedConfig | None = None,
+    tokenizer: str | PreTrainedTokenizer | PreTrainedTokenizerFast | None = None,
+    feature_extractor: str | FeatureExtractionMixin | None = None,
+    image_processor: str | BaseImageProcessor | None = None,
+    processor: str | ProcessorMixin | None = None,
     # framework: Optional[str] = None, # we leave it as None to trigger model loading with ort_infer_framework_load_model
-    revision: Optional[str] = None,
+    revision: str | None = None,
     use_fast: bool = True,
-    token: Optional[Union[str, bool]] = None,
-    device: Optional[Union[int, str, "torch.device"]] = None,
+    token: str | bool | None = None,
+    device: int | str | torch.device | None = None,
     # device_map: Optional[Union[str, dict[str, Union[int, str]]]] = None, # we do not support device_map with ORTModel
     # torch_dtype: Optional[Union[str, "torch.dtype"]] = "auto", we don't support model export to different dtypes yet
-    trust_remote_code: Optional[bool] = None,
-    model_kwargs: Optional[dict[str, Any]] = None,
-    pipeline_class: Optional[Any] = None,
+    trust_remote_code: bool | None = None,
+    model_kwargs: dict[str, Any] | None = None,
+    pipeline_class: Any | None = None,
     accelerator: str | None = None,
     **kwargs: Any,
 ) -> Pipeline:

--- a/optimum/onnxruntime/pipelines.py
+++ b/optimum/onnxruntime/pipelines.py
@@ -1,0 +1,358 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pipelines running different backends."""
+
+import contextlib
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+import torch
+import transformers.pipelines
+from transformers import AutoConfig, Pipeline
+from transformers import pipeline as transformers_pipeline
+
+from optimum.utils import is_onnxruntime_available
+
+
+if TYPE_CHECKING:
+    from transformers import (
+        BaseImageProcessor,
+        FeatureExtractionMixin,
+        PretrainedConfig,
+        PreTrainedTokenizer,
+        PreTrainedTokenizerFast,
+        ProcessorMixin,
+    )
+
+
+if is_onnxruntime_available():
+    from optimum.onnxruntime import (
+        ORTModelForAudioClassification,
+        ORTModelForCausalLM,
+        ORTModelForCTC,
+        ORTModelForFeatureExtraction,
+        ORTModelForImageClassification,
+        ORTModelForImageToImage,
+        ORTModelForMaskedLM,
+        ORTModelForQuestionAnswering,
+        ORTModelForSemanticSegmentation,
+        ORTModelForSeq2SeqLM,
+        ORTModelForSequenceClassification,
+        ORTModelForSpeechSeq2Seq,
+        ORTModelForTokenClassification,
+        ORTModelForVision2Seq,
+    )
+    from optimum.onnxruntime.modeling_ort import ORTModel
+
+    ORT_TASKS_MAPPING = {
+        "audio-classification": (ORTModelForAudioClassification,),
+        "automatic-speech-recognition": (ORTModelForCTC, ORTModelForSpeechSeq2Seq),
+        "feature-extraction": (ORTModelForFeatureExtraction,),
+        "fill-mask": (ORTModelForMaskedLM,),
+        "image-classification": (ORTModelForImageClassification,),
+        "image-segmentation": (ORTModelForSemanticSegmentation,),  # TODO: we need to add ORTModelForImageSegmentation
+        "image-to-image": (ORTModelForImageToImage,),
+        "image-to-text": (ORTModelForVision2Seq,),
+        "question-answering": (ORTModelForQuestionAnswering,),
+        "summarization": (ORTModelForSeq2SeqLM,),
+        "text2text-generation": (ORTModelForSeq2SeqLM,),
+        "text-classification": (ORTModelForSequenceClassification,),
+        "text-generation": (ORTModelForCausalLM,),
+        "token-classification": (ORTModelForTokenClassification,),
+        "translation": (ORTModelForSeq2SeqLM,),
+        "zero-shot-classification": (ORTModelForSequenceClassification,),
+    }
+else:
+    ORT_TASKS_MAPPING = {}
+
+
+def get_ort_model_class(
+    task: str, config: Optional["PretrainedConfig"] = None, model_id: Optional[str] = None, **model_kwargs
+):
+    if task.startswith("translation_"):
+        # the pipeline registery takes care of getting the right model id for translation_xx_to_yy
+        task = "translation"
+
+    if task not in ORT_TASKS_MAPPING:
+        raise KeyError(
+            f"Task '{task}' is not supported by ONNX Runtime. Only {list(ORT_TASKS_MAPPING.keys())} are supported."
+        )
+
+    if task == "automatic-speech-recognition":
+        if config is None:
+            hub_kwargs = {
+                "trust_remote_code": model_kwargs.pop("trust_remote_code", False),
+                "revision": model_kwargs.pop("revision", None),
+                "token": model_kwargs.pop("token", None),
+            }
+            config = AutoConfig.from_pretrained(model_id, **hub_kwargs)
+        if any(arch.endswith("ForCTC") for arch in config.architectures):
+            ort_model_class = ORT_TASKS_MAPPING[task][0]
+        else:
+            ort_model_class = ORT_TASKS_MAPPING[task][1]
+    else:
+        ort_model_class = ORT_TASKS_MAPPING[task][0]
+
+    return ort_model_class
+
+
+# a modified transformers.pipelines.base.infer_framework_load_model that loads ORT models
+def ort_infer_framework_load_model(
+    model,
+    config: Optional["PretrainedConfig"] = None,
+    model_classes: Optional[dict[str, tuple[type]]] = None,
+    task: Optional[str] = None,
+    framework: Optional[str] = None,
+    **model_kwargs,
+):
+    if isinstance(model, str):
+        model_kwargs.pop("torch_dtype", None)  # not supported for ORTModel
+        model_kwargs.pop("_commit_hash", None)  # not needed for ORTModel
+        ort_model_class = get_ort_model_class(task, config, model, **model_kwargs)
+        ort_model = ort_model_class.from_pretrained(model, **model_kwargs)
+    elif isinstance(model, ORTModel):
+        ort_model = model
+    else:
+        raise TypeError(
+            f"""Model {model} is not supported. Please provide a valid model either as string or ORTModel.
+            You can also provide non model then a default one will be used"""
+        )
+
+    return "pt", ort_model
+
+
+@contextlib.contextmanager
+def patch_pipelines_to_load_ort_model():
+    original_infer_framework_load_model = transformers.pipelines.infer_framework_load_model
+
+    transformers.pipelines.infer_framework_load_model = ort_infer_framework_load_model
+    try:
+        yield
+    finally:
+        transformers.pipelines.infer_framework_load_model = original_infer_framework_load_model
+
+
+# The docstring is simply a copy of transformers.pipelines.pipeline's doc with minor modifications
+# to reflect the fact that this pipeline loads ONNX Runtime models that inherit from ORTModel
+def pipeline(  # noqa: D417
+    task: Optional[str] = None,
+    model: Optional[Union[str, "ORTModel"]] = None,
+    config: Optional[Union[str, "PretrainedConfig"]] = None,
+    tokenizer: Optional[Union[str, "PreTrainedTokenizer", "PreTrainedTokenizerFast"]] = None,
+    feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,
+    image_processor: Optional[Union[str, "BaseImageProcessor"]] = None,
+    processor: Optional[Union[str, "ProcessorMixin"]] = None,
+    # framework: Optional[str] = None, # we leave it as None to trigger model loading with ort_infer_framework_load_model
+    revision: Optional[str] = None,
+    use_fast: bool = True,
+    token: Optional[Union[str, bool]] = None,
+    device: Optional[Union[int, str, "torch.device"]] = None,
+    # device_map: Optional[Union[str, dict[str, Union[int, str]]]] = None, # we do not support device_map with ORTModel
+    # torch_dtype: Optional[Union[str, "torch.dtype"]] = "auto", we don't support model export to different dtypes yet
+    trust_remote_code: Optional[bool] = None,
+    model_kwargs: Optional[dict[str, Any]] = None,
+    pipeline_class: Optional[Any] = None,
+    accelerator: str | None = None,
+    **kwargs: Any,
+) -> Pipeline:
+    """Utility factory method to build a [`Pipeline`] with an ONNX Runtime model, similar to `transformers.pipeline`.
+
+    A pipeline consists of:
+
+        - One or more components for pre-processing model inputs, such as a [tokenizer](tokenizer),
+        [image_processor](image_processor), [feature_extractor](feature_extractor), or [processor](processors).
+        - A [model](model) that generates predictions from the inputs.
+        - Optional post-processing steps to refine the model's output, which can also be handled by processors.
+
+    <Tip>
+    While there are such optional arguments as `tokenizer`, `feature_extractor`, `image_processor`, and `processor`,
+    they shouldn't be specified all at once. If these components are not provided, `pipeline` will try to load
+    required ones automatically. In case you want to provide these components explicitly, please refer to a
+    specific pipeline in order to get more details regarding what components are required.
+    </Tip>
+
+    Args:
+        task (`str`):
+            The task defining which pipeline will be returned. Currently accepted tasks are:
+
+            - `"audio-classification"`: will return a [`AudioClassificationPipeline`].
+            - `"automatic-speech-recognition"`: will return a [`AutomaticSpeechRecognitionPipeline`].
+            - `"depth-estimation"`: will return a [`DepthEstimationPipeline`].
+            - `"document-question-answering"`: will return a [`DocumentQuestionAnsweringPipeline`].
+            - `"feature-extraction"`: will return a [`FeatureExtractionPipeline`].
+            - `"fill-mask"`: will return a [`FillMaskPipeline`]:.
+            - `"image-classification"`: will return a [`ImageClassificationPipeline`].
+            - `"image-feature-extraction"`: will return an [`ImageFeatureExtractionPipeline`].
+            - `"image-segmentation"`: will return a [`ImageSegmentationPipeline`].
+            - `"image-text-to-text"`: will return a [`ImageTextToTextPipeline`].
+            - `"image-to-image"`: will return a [`ImageToImagePipeline`].
+            - `"image-to-text"`: will return a [`ImageToTextPipeline`].
+            - `"mask-generation"`: will return a [`MaskGenerationPipeline`].
+            - `"object-detection"`: will return a [`ObjectDetectionPipeline`].
+            - `"question-answering"`: will return a [`QuestionAnsweringPipeline`].
+            - `"summarization"`: will return a [`SummarizationPipeline`].
+            - `"table-question-answering"`: will return a [`TableQuestionAnsweringPipeline`].
+            - `"text2text-generation"`: will return a [`Text2TextGenerationPipeline`].
+            - `"text-classification"` (alias `"sentiment-analysis"` available): will return a
+              [`TextClassificationPipeline`].
+            - `"text-generation"`: will return a [`TextGenerationPipeline`]:.
+            - `"text-to-audio"` (alias `"text-to-speech"` available): will return a [`TextToAudioPipeline`]:.
+            - `"token-classification"` (alias `"ner"` available): will return a [`TokenClassificationPipeline`].
+            - `"translation"`: will return a [`TranslationPipeline`].
+            - `"translation_xx_to_yy"`: will return a [`TranslationPipeline`].
+            - `"video-classification"`: will return a [`VideoClassificationPipeline`].
+            - `"visual-question-answering"`: will return a [`VisualQuestionAnsweringPipeline`].
+            - `"zero-shot-classification"`: will return a [`ZeroShotClassificationPipeline`].
+            - `"zero-shot-image-classification"`: will return a [`ZeroShotImageClassificationPipeline`].
+            - `"zero-shot-audio-classification"`: will return a [`ZeroShotAudioClassificationPipeline`].
+            - `"zero-shot-object-detection"`: will return a [`ZeroShotObjectDetectionPipeline`].
+
+        model (`str` or [`ORTModel`], *optional*):
+            The model that will be used by the pipeline to make predictions. This can be a model identifier or an
+            actual instance of a ONNX Runtime model inheriting from [`ORTModel`].
+
+            If not provided, the default for the `task` will be loaded.
+        config (`str` or [`PretrainedConfig`], *optional*):
+            The configuration that will be used by the pipeline to instantiate the model. This can be a model
+            identifier or an actual pretrained model configuration inheriting from [`PretrainedConfig`].
+
+            If not provided, the default configuration file for the requested model will be used. That means that if
+            `model` is given, its default configuration will be used. However, if `model` is not supplied, this
+            `task`'s default model's config is used instead.
+        tokenizer (`str` or [`PreTrainedTokenizer`], *optional*):
+            The tokenizer that will be used by the pipeline to encode data for the model. This can be a model
+            identifier or an actual pretrained tokenizer inheriting from [`PreTrainedTokenizer`].
+
+            If not provided, the default tokenizer for the given `model` will be loaded (if it is a string). If `model`
+            is not specified or not a string, then the default tokenizer for `config` is loaded (if it is a string).
+            However, if `config` is also not given or not a string, then the default tokenizer for the given `task`
+            will be loaded.
+        feature_extractor (`str` or [`PreTrainedFeatureExtractor`], *optional*):
+            The feature extractor that will be used by the pipeline to encode data for the model. This can be a model
+            identifier or an actual pretrained feature extractor inheriting from [`PreTrainedFeatureExtractor`].
+
+            Feature extractors are used for non-NLP models, such as Speech or Vision models as well as multi-modal
+            models. Multi-modal models will also require a tokenizer to be passed.
+
+            If not provided, the default feature extractor for the given `model` will be loaded (if it is a string). If
+            `model` is not specified or not a string, then the default feature extractor for `config` is loaded (if it
+            is a string). However, if `config` is also not given or not a string, then the default feature extractor
+            for the given `task` will be loaded.
+        image_processor (`str` or [`BaseImageProcessor`], *optional*):
+            The image processor that will be used by the pipeline to preprocess images for the model. This can be a
+            model identifier or an actual image processor inheriting from [`BaseImageProcessor`].
+
+            Image processors are used for Vision models and multi-modal models that require image inputs. Multi-modal
+            models will also require a tokenizer to be passed.
+
+            If not provided, the default image processor for the given `model` will be loaded (if it is a string). If
+            `model` is not specified or not a string, then the default image processor for `config` is loaded (if it is
+            a string).
+        processor (`str` or [`ProcessorMixin`], *optional*):
+            The processor that will be used by the pipeline to preprocess data for the model. This can be a model
+            identifier or an actual processor inheriting from [`ProcessorMixin`].
+
+            Processors are used for multi-modal models that require multi-modal inputs, for example, a model that
+            requires both text and image inputs.
+
+            If not provided, the default processor for the given `model` will be loaded (if it is a string). If `model`
+            is not specified or not a string, then the default processor for `config` is loaded (if it is a string).
+        framework (`str`, *optional*):
+            The framework to use, either `"pt"` for PyTorch or `"tf"` for TensorFlow. The specified framework must be
+            installed.
+
+            If no framework is specified, will default to the one currently installed. If no framework is specified and
+            both frameworks are installed, will default to the framework of the `model`, or to PyTorch if no model is
+            provided.
+        revision (`str`, *optional*, defaults to `"main"`):
+            When passing a task name or a string model identifier: The specific model version to use. It can be a
+            branch name, a tag name, or a commit id, since we use a git-based system for storing models and other
+            artifacts on huggingface.co, so `revision` can be any identifier allowed by git.
+        use_fast (`bool`, *optional*, defaults to `True`):
+            Whether or not to use a Fast tokenizer if possible (a [`PreTrainedTokenizerFast`]).
+        use_auth_token (`str` or *bool*, *optional*):
+            The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+            when running `hf auth login` (stored in `~/.huggingface`).
+        device (`int` or `str` or `torch.device`):
+            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"mps"`, or a GPU ordinal rank like `1`) on which this
+            pipeline will be allocated.
+        device_map (`str` or `dict[str, Union[int, str, torch.device]`, *optional*):
+            Sent directly as `model_kwargs` (just a simpler shortcut). When `accelerate` library is present, set
+            `device_map="auto"` to compute the most optimized `device_map` automatically (see
+            [here](https://huggingface.co/docs/accelerate/main/en/package_reference/big_modeling#accelerate.cpu_offload)
+            for more information).
+
+            <Tip warning={true}>
+
+            Do not use `device_map` AND `device` at the same time as they will conflict
+
+            </Tip>
+
+        torch_dtype (`str` or `torch.dtype`, *optional*):
+            Sent directly as `model_kwargs` (just a simpler shortcut) to use the available precision for this model
+            (`torch.float16`, `torch.bfloat16`, ... or `"auto"`).
+        trust_remote_code (`bool`, *optional*, defaults to `False`):
+            Whether or not to allow for custom code defined on the Hub in their own modeling, configuration,
+            tokenization or even pipeline files. This option should only be set to `True` for repositories you trust
+            and in which you have read the code, as it will execute code present on the Hub on your local machine.
+        model_kwargs (`dict[str, Any]`, *optional*):
+            Additional dictionary of keyword arguments passed along to the model's `from_pretrained(...,
+            **model_kwargs)` function.
+        kwargs (`dict[str, Any]`, *optional*):
+            Additional keyword arguments passed along to the specific pipeline init (see the documentation for the
+            corresponding pipeline class for possible values).
+
+    Returns:
+        [`Pipeline`]: A suitable pipeline for the task.
+
+    Examples:
+    ```python
+    >>> from optimum.onnxruntime import pipeline
+
+    >>> # Sentiment analysis pipeline
+    >>> analyzer = pipeline("sentiment-analysis")
+
+    >>> # Question answering pipeline, specifying the checkpoint identifier
+    >>> oracle = pipeline(
+    ...     "question-answering", model="distilbert/distilbert-base-cased-distilled-squad", tokenizer="google-bert/bert-base-cased"
+    ... )
+
+    >>> # Named entity recognition pipeline, passing in a specific model and tokenizer
+    >>> model = ORTModelForTokenClassification.from_pretrained("dbmdz/bert-large-cased-finetuned-conll03-english")
+    >>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")
+    >>> recognizer = pipeline("ner", model=model, tokenizer=tokenizer)
+    ```
+    """
+    with patch_pipelines_to_load_ort_model():
+        pipeline_with_ort_model = transformers_pipeline(
+            task=task,
+            model=model,
+            config=config,
+            tokenizer=tokenizer,
+            feature_extractor=feature_extractor,
+            image_processor=image_processor,
+            processor=processor,
+            # framework=framework,
+            revision=revision,
+            use_fast=use_fast,
+            token=token,
+            device=device,
+            # device_map=device_map,
+            # torch_dtype=torch_dtype,
+            trust_remote_code=trust_remote_code,
+            model_kwargs=model_kwargs,
+            pipeline_class=pipeline_class,
+            **kwargs,
+        )
+
+    return pipeline_with_ort_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ dynamic = ["version"]
 description = "Optimum ONNX is an interface between the Hugging Face libraries and ONNX / ONNX Runtime"
 readme = "README.md"
 requires-python = ">=3.9.0"
-license = {text = "Apache-2.0"}
+license = { text = "Apache-2.0" }
 authors = [
-    {name = "HuggingFace Inc. Special Ops Team", email = "hardware@huggingface.co"}
+    { name = "HuggingFace Inc. Special Ops Team", email = "hardware@huggingface.co" },
 ]
 keywords = ["transformers", "quantization", "inference", "onnx", "onnxruntime"]
 classifiers = [
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "optimum",
+    "optimum @ git+https://github.com/huggingface/optimum",
     "transformers>=4.36,<4.54.0",
     "onnx",
 ]
@@ -67,7 +67,7 @@ include-package-data = true
 include = ["optimum*"]
 
 [tool.setuptools.dynamic]
-version = {attr = "optimum.onnx.version.__version__"}
+version = { attr = "optimum.onnx.version.__version__" }
 
 [tool.ruff]
 line-length = 119
@@ -75,48 +75,48 @@ target-version = "py39"
 
 [tool.ruff.lint]
 ignore = [
-    "B9",  # Opinionated bugbear rules
+    "B9",      # Opinionated bugbear rules
     "C901",
     "D1",
     "D205",
     "D401",
     "D403",
-    "E501",  # Never enforce line length violations
+    "E501",    # Never enforce line length violations
     "E741",
-    "G004",  # FIXME: Re-enable when autofix is available
-    "NPY002", # We may not always need a generator
+    "G004",    # FIXME: Re-enable when autofix is available
+    "NPY002",  # We may not always need a generator
     "PERF203", # try-except in loops sometimes necessary
     "PERF401", # List comprehension is not always readable
-    "SIM102", # Collapible if statements are not always more readable
-    "SIM108", # We don't always encourage ternary operators
-    "SIM114", # Don't always combine if branches for debugability
-    "SIM116", # Don't use dict lookup to replace if-else
-    "TRY003", # Messages can be constructed in the exception
+    "SIM102",  # Collapible if statements are not always more readable
+    "SIM108",  # We don't always encourage ternary operators
+    "SIM114",  # Don't always combine if branches for debugability
+    "SIM116",  # Don't use dict lookup to replace if-else
+    "TRY003",  # Messages can be constructed in the exception
 ]
 select = [
-    "B", # flake8-bugbear
-    "C", # flake8-comprehensions
-    "D", # pydocstyle
-    "E", # pycodestyle
-    "F", # Pyflakes
-    "G", # flake8-logging-format
-    "I", # isort
-    "ISC", # flake8-implicit-str-concat
-    "LOG", # flake8-logging
-    "N", # pep8-naming
-    "NPY", # modern numpy
+    "B",    # flake8-bugbear
+    "C",    # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle
+    "F",    # Pyflakes
+    "G",    # flake8-logging-format
+    "I",    # isort
+    "ISC",  # flake8-implicit-str-concat
+    "LOG",  # flake8-logging
+    "N",    # pep8-naming
+    "NPY",  # modern numpy
     "PERF", # Perflint
-    "PIE", # flake8-pie
-    "PYI", # flake8-pyi
-    "RUF", # Ruff-specific rules
-    "SIM", # flake8-simplify
+    "PIE",  # flake8-pie
+    "PYI",  # flake8-pyi
+    "RUF",  # Ruff-specific rules
+    "SIM",  # flake8-simplify
     "SLOT", # flake8-slot
-    "T10", # flake8-debugger
-    "TID", # Disallow relative imports
-    "TRY", # flake8-try-except-raise
-    "UP", # pyupgrade
-    "W", # pycodestyle
-    "YTT", # flake8-2020
+    "T10",  # flake8-debugger
+    "TID",  # Disallow relative imports
+    "TRY",  # flake8-try-except-raise
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
+    "YTT",  # flake8-2020
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "optimum @ git+https://github.com/huggingface/optimum.git",
+    "optimum",
     "transformers>=4.36,<4.54.0",
     "onnx",
 ]

--- a/tests/onnxruntime/test_decoder.py
+++ b/tests/onnxruntime/test_decoder.py
@@ -54,7 +54,7 @@ from optimum.onnxruntime import (
     ONNX_WEIGHTS_NAME,
     ORTModelForCausalLM,
 )
-from optimum.pipelines import pipeline
+from optimum.onnxruntime.pipelines import pipeline
 from optimum.utils.import_utils import is_transformers_version
 from optimum.utils.logging import get_logger
 from optimum.utils.testing_utils import grid_parameters, remove_directory, require_hf_token

--- a/tests/onnxruntime/test_decoder.py
+++ b/tests/onnxruntime/test_decoder.py
@@ -53,8 +53,8 @@ from optimum.onnxruntime import (
     ONNX_DECODER_WITH_PAST_NAME,
     ONNX_WEIGHTS_NAME,
     ORTModelForCausalLM,
+    pipeline,
 )
-from optimum.onnxruntime.pipelines import pipeline
 from optimum.utils.import_utils import is_transformers_version
 from optimum.utils.logging import get_logger
 from optimum.utils.testing_utils import grid_parameters, remove_directory, require_hf_token

--- a/tests/onnxruntime/test_diffusion.py
+++ b/tests/onnxruntime/test_diffusion.py
@@ -128,6 +128,24 @@ class ORTDiffusionPipelineTest(TestCase):
             ORTDiffusionPipeline.from_pretrained(self.TINY_ONNX_STABLE_DIFFUSION, provider="FooExecutionProvider")
 
     @require_diffusers
+    def test_automatic_export(self):
+        # export from torch to onnx without export=True
+        pipe = ORTDiffusionPipeline.from_pretrained(self.TINY_TORCH_STABLE_DIFFUSION)
+        self.assert_pipeline_sanity(pipe)
+
+    @require_diffusers
+    def test_fp16_export(self):
+        for kwargs in ({"torch_dtype": torch.float16}, {"dtype": "fp16"}):
+            pipe = ORTDiffusionPipeline.from_pretrained(self.TINY_TORCH_STABLE_DIFFUSION, **kwargs)
+            self.assert_pipeline_sanity(pipe)
+            self.assertEqual(pipe.dtype, torch.float16)
+            self.assertEqual(pipe.vae.dtype, torch.float16)
+            self.assertEqual(pipe.unet.dtype, torch.float16)
+            self.assertEqual(pipe.vae_encoder.dtype, torch.float16)
+            self.assertEqual(pipe.vae_decoder.dtype, torch.float16)
+            self.assertEqual(pipe.text_encoder.dtype, torch.float16)
+
+    @require_diffusers
     def test_save_diffusion_pipeline(self):
         with TemporaryDirectory() as tmpdirname:
             pipe = ORTDiffusionPipeline.from_pretrained(self.TINY_ONNX_STABLE_DIFFUSION)

--- a/tests/onnxruntime/test_diffusion.py
+++ b/tests/onnxruntime/test_diffusion.py
@@ -56,13 +56,8 @@ if torch.cuda.is_available():
         PROVIDERS.append("TensorrtExecutionProvider")
 
 
-def get_generator(framework, seed):
-    if framework == "np":
-        return np.random.RandomState(seed)
-    elif framework == "pt":
-        return torch.Generator().manual_seed(seed)
-    else:
-        raise ValueError(f"Unknown framework: {framework}")
+def get_generator(seed):
+    return torch.Generator().manual_seed(seed)
 
 
 def generate_prompts(batch_size=1):
@@ -309,8 +304,8 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
         for output_type in ["latent", "np", "pt"]:
             inputs["output_type"] = output_type
 
-            ort_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
-            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            ort_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
+            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator(SEED)).images
 
             np.testing.assert_allclose(ort_images, diffusers_images, atol=self.ATOL, rtol=self.RTOL)
 
@@ -331,12 +326,12 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
 
             # makes sure io binding is not used
             ort_pipeline.use_io_binding = False
-            images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertEqual(len(diffusion_model._io_binding.get_outputs()), 0)
 
             # makes sure io binding is effectively used
             ort_pipeline.use_io_binding = True
-            io_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            io_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertGreaterEqual(len(diffusion_model._io_binding.get_outputs()), 1)
 
             # makes sure the outputs are the same
@@ -420,18 +415,14 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
 
         height, width, batch_size = 64, 64, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
-
         pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[model_arch])
 
-        for generator_framework in ["np", "pt"]:
-            ort_outputs_1 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_2 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_3 = pipeline(**inputs, generator=get_generator(generator_framework, SEED + 1))
+        ort_outputs_1 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_2 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_3 = pipeline(**inputs, generator=get_generator(SEED + 1))
 
-            self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
-            np.testing.assert_allclose(
-                ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL
-            )
+        self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
+        np.testing.assert_allclose(ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL)
 
     @parameterized.expand(NEGATIVE_PROMPT_SUPPORTED_ARCHITECTURES)
     def test_negative_prompt(self, model_arch: str):
@@ -445,8 +436,8 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
         ort_pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[model_arch])
         diffusers_pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch])
 
-        ort_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
-        diffusers_images = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+        ort_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
+        diffusers_images = diffusers_pipeline(**inputs, generator=get_generator(SEED)).images
 
         np.testing.assert_allclose(ort_images, diffusers_images, atol=self.ATOL, rtol=self.RTOL)
 
@@ -471,8 +462,8 @@ class ORTPipelineForText2ImageTest(ORTModelTestMixin):
         height, width, batch_size = 32, 64, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        ort_output = ort_pipeline(**inputs, generator=get_generator("pt", SEED))
-        diffusers_output = pipeline(**inputs, generator=get_generator("pt", SEED))
+        ort_output = ort_pipeline(**inputs, generator=get_generator(SEED))
+        diffusers_output = pipeline(**inputs, generator=get_generator(SEED))
 
         ort_nsfw_content_detected = ort_output.nsfw_content_detected
         diffusers_nsfw_content_detected = diffusers_output.nsfw_content_detected
@@ -653,8 +644,8 @@ class ORTPipelineForImage2ImageTest(ORTModelTestMixin):
         for output_type in ["latent", "np", "pt"]:
             inputs["output_type"] = output_type
 
-            ort_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
-            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            ort_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
+            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator(SEED)).images
 
             np.testing.assert_allclose(ort_images, diffusers_images, atol=self.ATOL, rtol=self.RTOL)
 
@@ -675,12 +666,12 @@ class ORTPipelineForImage2ImageTest(ORTModelTestMixin):
 
             # makes sure io binding is not used
             ort_pipeline.use_io_binding = False
-            images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertEqual(len(diffusion_model._io_binding.get_outputs()), 0)
 
             # makes sure io binding is effectively used
             ort_pipeline.use_io_binding = True
-            io_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            io_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertGreaterEqual(len(diffusion_model._io_binding.get_outputs()), 1)
 
             # makes sure the outputs are the same
@@ -696,18 +687,14 @@ class ORTPipelineForImage2ImageTest(ORTModelTestMixin):
 
         height, width, batch_size = 64, 64, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
-
         pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[model_arch])
 
-        for generator_framework in ["np", "pt"]:
-            ort_outputs_1 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_2 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_3 = pipeline(**inputs, generator=get_generator(generator_framework, SEED + 1))
+        ort_outputs_1 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_2 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_3 = pipeline(**inputs, generator=get_generator(SEED + 1))
 
-            self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
-            np.testing.assert_allclose(
-                ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL
-            )
+        self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
+        np.testing.assert_allclose(ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL)
 
     @parameterized.expand(["stable-diffusion", "latent-consistency"])
     @require_diffusers
@@ -730,8 +717,8 @@ class ORTPipelineForImage2ImageTest(ORTModelTestMixin):
         height, width, batch_size = 32, 64, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        ort_output = ort_pipeline(**inputs, generator=get_generator("pt", SEED))
-        diffusers_output = pipeline(**inputs, generator=get_generator("pt", SEED))
+        ort_output = ort_pipeline(**inputs, generator=get_generator(SEED))
+        diffusers_output = pipeline(**inputs, generator=get_generator(SEED))
 
         ort_nsfw_content_detected = ort_output.nsfw_content_detected
         diffusers_nsfw_content_detected = diffusers_output.nsfw_content_detected
@@ -917,8 +904,8 @@ class ORTPipelineForInpaintingTest(ORTModelTestMixin):
         for output_type in ["latent", "np", "pt"]:
             inputs["output_type"] = output_type
 
-            ort_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
-            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            ort_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
+            diffusers_images = diffusers_pipeline(**inputs, generator=get_generator(SEED)).images
 
             np.testing.assert_allclose(ort_images, diffusers_images, atol=self.ATOL, rtol=self.RTOL)
 
@@ -939,12 +926,12 @@ class ORTPipelineForInpaintingTest(ORTModelTestMixin):
 
             # makes sure io binding is not used
             ort_pipeline.use_io_binding = False
-            images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertEqual(len(diffusion_model._io_binding.get_outputs()), 0)
 
             # makes sure io binding is effectively used
             ort_pipeline.use_io_binding = True
-            io_images = ort_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            io_images = ort_pipeline(**inputs, generator=get_generator(SEED)).images
             self.assertGreaterEqual(len(diffusion_model._io_binding.get_outputs()), 1)
 
             # makes sure the outputs are the same
@@ -963,15 +950,12 @@ class ORTPipelineForInpaintingTest(ORTModelTestMixin):
 
         pipeline = self.ORTMODEL_CLASS.from_pretrained(self.onnx_model_dirs[model_arch])
 
-        for generator_framework in ["np", "pt"]:
-            ort_outputs_1 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_2 = pipeline(**inputs, generator=get_generator(generator_framework, SEED))
-            ort_outputs_3 = pipeline(**inputs, generator=get_generator(generator_framework, SEED + 1))
+        ort_outputs_1 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_2 = pipeline(**inputs, generator=get_generator(SEED))
+        ort_outputs_3 = pipeline(**inputs, generator=get_generator(SEED + 1))
 
-            self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
-            np.testing.assert_allclose(
-                ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL
-            )
+        self.assertFalse(np.array_equal(ort_outputs_1.images[0], ort_outputs_3.images[0]))
+        np.testing.assert_allclose(ort_outputs_1.images[0], ort_outputs_2.images[0], atol=self.ATOL, rtol=self.RTOL)
 
     @parameterized.expand(["stable-diffusion"])
     @require_diffusers
@@ -994,8 +978,8 @@ class ORTPipelineForInpaintingTest(ORTModelTestMixin):
         height, width, batch_size = 32, 64, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
 
-        ort_output = ort_pipeline(**inputs, generator=get_generator("pt", SEED))
-        diffusers_output = pipeline(**inputs, generator=get_generator("pt", SEED))
+        ort_output = ort_pipeline(**inputs, generator=get_generator(SEED))
+        diffusers_output = pipeline(**inputs, generator=get_generator(SEED))
 
         ort_nsfw_content_detected = ort_output.nsfw_content_detected
         diffusers_nsfw_content_detected = diffusers_output.nsfw_content_detected

--- a/tests/onnxruntime/test_diffusion.py
+++ b/tests/onnxruntime/test_diffusion.py
@@ -32,6 +32,7 @@ from huggingface_hub.constants import HF_HUB_CACHE
 from parameterized import parameterized
 from PIL import Image
 from testing_utils import MODEL_NAMES, SEED, ORTModelTestMixin, TemporaryHubRepo
+from transformers.utils.hub import http_user_agent
 
 from optimum.onnxruntime import (
     ORTDiffusionPipeline,
@@ -99,7 +100,11 @@ class ORTDiffusionPipelineTest(TestCase):
 
     @require_diffusers
     def test_load_diffusion_pipeline_from_path(self):
-        path = snapshot_download(repo_id=self.TINY_ONNX_STABLE_DIFFUSION, allow_patterns=["*.onnx", "*.json", "*.txt"])
+        path = snapshot_download(
+            repo_id=self.TINY_ONNX_STABLE_DIFFUSION,
+            allow_patterns=["*.onnx", "*.json", "*.txt"],
+            user_agent=http_user_agent(),
+        )
         pipe = ORTDiffusionPipeline.from_pretrained(path, local_files_only=True)
         self.assert_pipeline_sanity(pipe)
 
@@ -111,7 +116,11 @@ class ORTDiffusionPipelineTest(TestCase):
         with self.assertRaises(Exception):  # noqa: B017
             _ = ORTDiffusionPipeline.from_pretrained(self.TINY_ONNX_STABLE_DIFFUSION, local_files_only=True)
 
-        snapshot_download(repo_id=self.TINY_ONNX_STABLE_DIFFUSION, allow_patterns=["*.onnx", "*.json", "*.txt"])
+        snapshot_download(
+            repo_id=self.TINY_ONNX_STABLE_DIFFUSION,
+            allow_patterns=["*.onnx", "*.json", "*.txt"],
+            user_agent=http_user_agent(),
+        )
         pipe = ORTDiffusionPipeline.from_pretrained(self.TINY_ONNX_STABLE_DIFFUSION, local_files_only=True)
         self.assert_pipeline_sanity(pipe)
 

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -92,7 +92,7 @@ from optimum.onnxruntime import (
 )
 from optimum.onnxruntime.modeling_ort import ORTModel
 from optimum.onnxruntime.modeling_seq2seq import ORTDecoderForSeq2Seq, ORTEncoder
-from optimum.pipelines import pipeline
+from optimum.onnxruntime.pipelines import pipeline
 from optimum.utils import CONFIG_NAME, logging
 from optimum.utils.save_utils import maybe_load_preprocessors
 from optimum.utils.testing_utils import grid_parameters, remove_directory, require_hf_token, require_ort_rocm

--- a/tests/onnxruntime/test_modeling.py
+++ b/tests/onnxruntime/test_modeling.py
@@ -89,10 +89,10 @@ from optimum.onnxruntime import (
     ORTModelForSpeechSeq2Seq,
     ORTModelForTokenClassification,
     ORTModelForVision2Seq,
+    pipeline,
 )
 from optimum.onnxruntime.modeling_ort import ORTModel
 from optimum.onnxruntime.modeling_seq2seq import ORTDecoderForSeq2Seq, ORTEncoder
-from optimum.onnxruntime.pipelines import pipeline
 from optimum.utils import CONFIG_NAME, logging
 from optimum.utils.save_utils import maybe_load_preprocessors
 from optimum.utils.testing_utils import grid_parameters, remove_directory, require_hf_token, require_ort_rocm


### PR DESCRIPTION
I tried to fix the image processor loading issue I encountered in #34 (image-to-text task) but It was difficult without copying a big chunk of the preprocessors loading logic in transformers.pipelines.pipeline.
In this approach we only need to handle the task to class mapping which is simpler than handling the preprocessors loading.
I also added some specific docs for pipelines, mostly linking to transformers.pipeline docs and fixed diffusion docs not showing __call__ signature/params/docstring (check [here](https://moon-ci-docs.huggingface.co/docs/optimum-onnx/pr_41/en/onnxruntime/package_reference/modeling_diffusion#optimum.onnxruntime.ORTStableDiffusionPipeline.__call__))