### PR TITLE
Fix gpt-oss export for mxfp4 quantized models

### DIFF
--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -272,6 +272,7 @@ def main_export(
 
     custom_architecture = False
     loading_kwargs = {}
+    is_mxfp4 = False
     if library_name == "transformers":
         config = AutoConfig.from_pretrained(
             model_name_or_path,
@@ -288,7 +289,7 @@ def main_export(
         is_mxfp4 = getattr(config, "quantization_config", {}).get("quant_method", None) == "mxfp4"
         # mxfp4 quantized model will be dequantized to bf16
         if is_mxfp4 and is_transformers_version(">=", "4.55"):
-            torch_dtype = torch.bfloat16
+            torch_dtype = torch.float32 if model_type == "gpt_oss" else torch.bfloat16
             loading_kwargs["quantization_config"] = Mxfp4Config(dequantize=True)
 
         if model_type not in TasksManager._SUPPORTED_MODEL_TYPE:
@@ -356,6 +357,10 @@ def main_export(
         model_type = model.config.export_model_type
     else:
         model_type = model.config.model_type
+
+    # ensure gpt_oss models dtype is float32 (dequantized to bf16 by default leading to incompatible dtypes)
+    if is_mxfp4 and model_type == "gpt_oss":
+        model.to(torch.float32)
 
     if (
         not custom_architecture

--- a/tests/exporters/onnx/utils_tests.py
+++ b/tests/exporters/onnx/utils_tests.py
@@ -109,7 +109,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
-    "gpt_oss": "optimum-internal-testing/tiny-random-gpt-oss",
+    "gpt_oss": "echarlaix/tiny-random-gpt-oss-mxfp4",
     "gptj": "hf-internal-testing/tiny-random-GPTJModel",
     "granite": "hf-internal-testing/tiny-random-GraniteForCausalLM",
     "groupvit": "hf-internal-testing/tiny-random-groupvit",

--- a/tests/onnxruntime/test_decoder.py
+++ b/tests/onnxruntime/test_decoder.py
@@ -453,6 +453,10 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
         model = self.AUTOMODEL_CLASS.from_pretrained(
             MODEL_NAMES[model_arch], use_cache=use_cache, trust_remote_code=trust_remote_code
         ).eval()
+
+        if "mxfp4" in model_arch:
+            model.to(torch.float32)
+
         onnx_model = self.ORTMODEL_CLASS.from_pretrained(
             self.onnx_model_dirs[test_name], use_cache=use_cache, trust_remote_code=trust_remote_code
         )

--- a/tests/onnxruntime/test_decoder.py
+++ b/tests/onnxruntime/test_decoder.py
@@ -139,7 +139,7 @@ class ORTModelForCausalLMIntegrationTest(ORTModelTestMixin):
     if is_transformers_version(">=", str(StableLMOnnxConfig.MIN_TRANSFORMERS_VERSION)):
         SUPPORTED_ARCHITECTURES.append("stablelm")
     if is_transformers_version(">=", str(GPTOssOnnxConfig.MIN_TRANSFORMERS_VERSION)):
-        SUPPORTED_ARCHITECTURES.append("gpt_oss")
+        SUPPORTED_ARCHITECTURES.extend(["gpt_oss", "gpt_oss_mxfp4"])
 
     TRUST_REMOTE_CODE_MODELS = {"internlm2"}  # noqa: RUF012
 

--- a/tests/onnxruntime/testing_utils.py
+++ b/tests/onnxruntime/testing_utils.py
@@ -73,6 +73,7 @@ MODEL_NAMES = {
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
     "gpt_oss": "optimum-internal-testing/tiny-random-gpt-oss",
+    "gpt_oss_mxfp4": "echarlaix/tiny-random-gpt-oss-mxfp4",
     "gptj": "hf-internal-testing/tiny-random-GPTJForCausalLM",
     "granite": "hf-internal-testing/tiny-random-GraniteForCausalLM",
     "groupvit": "hf-internal-testing/tiny-random-groupvit",


### PR DESCRIPTION
- Ensure the model is dequantized to bf16 when quantized with mxfp4 (for now the `Mxfp4HfQuantizer` is only compatible with gpt_oss models)
- For gpt_oss we also load the model directly in fp32 to avoid invalid resulting onnx graph as the TopK operator can take bf16 inputs only since opset 24 which is very recent https://onnx.ai/onnx/operators/onnx__TopK.html (`DEFAULT_ONNX_OPSET` can be set to 24 in the future and this constraint released)
https://github.com/huggingface/transformers/blob/4a02bc7004285bdb12cc033e87ad2578ce2fa900/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L155
, an other issue seems to come from https://github.com/huggingface/transformers/blob/4a02bc7004285bdb12cc033e87ad2578ce2fa900/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L115 (currently looking into it)

Potential fix is to ensure the model is loaded in fp32 so that export is not broken for mxfp4 models (like [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b), if mxfp4 -> fp32 doesn't sound reasonable an other possibility is to revert gpt_oss export support to not block the release and add it back once fixed, @IlyasMoutawwakil wdyt ? 