### PR TITLE
Fix malformed pip commands that combine extras with a VCS direct reference. (pep508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 Before you begin, make sure you install all necessary libraries by running:
 
 ```bash
-pip install "optimum-onnx[onnxruntime]"@git+https://github.com/huggingface/optimum-onnx.git
+pip install "optimum-onnx[onnxruntime] @ git+https://github.com/huggingface/optimum-onnx.git"
 ```
 
 If you want to use the [GPU version of ONNX Runtime](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cuda-execution-provider), make sure the CUDA and cuDNN [requirements](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements) are satisfied, and install the additional dependencies by running :
 
 ```bash
-pip install "optimum-onnx[onnxruntime-gpu]"@git+https://github.com/huggingface/optimum-onnx.git
+pip install "optimum-onnx[onnxruntime-gpu] @ git+https://github.com/huggingface/optimum-onnx.git"
 ```
 
 To avoid conflicts between `onnxruntime` and `onnxruntime-gpu`, make sure the package `onnxruntime` is not installed by running `pip uninstall onnxruntime` prior to installing Optimum.

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -16,7 +16,7 @@ specific language governing permissions and limitations under the License.
 To install Optimum ONNX, you can do:
 
 ```bash
-pip install "optimum-onnx[onnxruntime]"@git+https://github.com/huggingface/optimum-onnx.git
+pip install "optimum-onnx[onnxruntime] @ git+https://github.com/huggingface/optimum-onnx.git"
 ```
 
 Optimum ONNX is a fast-moving project, and you may want to install from source with the following command:


### PR DESCRIPTION
Before:
    pip install "optimum-onnx[onnxruntime]"@git+https://github.com/huggingface/optimum-onnx.git
    pip install "optimum-onnx[onnxruntime-gpu]"@git+https://github.com/huggingface/optimum-onnx.git

After (PEP 508–compliant):
    pip install "optimum-onnx[onnxruntime] @ git+https://github.com/huggingface/optimum-onnx.git"
    pip install "optimum-onnx[onnxruntime-gpu] @ git+https://github.com/huggingface/optimum-onnx.git"

This prevents copy/paste install failures.

Note:
The Hugging Face docs page also shows the malformed command; that’s maintained on the docs site and will need a separate fix (or it may auto-sync from docs/source in this repo—if so, your README fix might need mirroring there). Example of the issue on the site: “Installation” page for Optimum ONNX.  (see https://huggingface.co/docs/optimum-onnx/installation)
