### PR TITLE
Fix logging missing argument

### DIFF
--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -2578,7 +2578,7 @@ class Pix2StructOnnxConfig(OnnxSeq2SeqConfigWithPast):
                 logger,
                 "Found transformers v4.46.0 while trying to export a Pix2Struct model, "
                 "this specific version of transformers is broken for this model. Please "
-                "upgrade to v4.46.1 or higher, or downgrade to v4.45.x."
+                "upgrade to v4.46.1 or higher, or downgrade to v4.45.x.",
             )
 
     @property


### PR DESCRIPTION
```
TypeError: warn_once() missing 1 required positional argument: 'msg'
```
https://github.com/huggingface/optimum/blob/79e8cd85a2ebf074c45e3046448c36f5d28e8766/optimum/utils/logging.py#L271