### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -22,14 +22,14 @@ jobs:
       PR_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: "20"
           cache-dependency-path: "kit/package-lock.json"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.11
 

--- a/.github/workflows/style_bot.yml
+++ b/.github/workflows/style_bot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@main
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@e000c1c89c65aee188041723456ac3a479416d4c  # main
     with:
       python_quality_dependencies: "[quality]"
       style_command_type: "style_only"

--- a/.github/workflows/test_onnxruntime_slow.yml
+++ b/.github/workflows/test_onnxruntime_slow.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         if: matrix.runs-on == 'ubuntu-24.04'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
 
       - name: Free Disk Space (macOS)
         if: matrix.runs-on == 'macos-15'
@@ -55,10 +55,10 @@ jobs:
           sudo rm -rf ~/Library/Caches/com.apple.dt.Xcode.SimulatorKit/*
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: optimum-onnx
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `quality.yml` | `actions/checkout` | `v5` | `v6.0.2` | `de0fac2e4500…` |
| `quality.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `build_documentation.yml` | `actions/checkout` | `v5` | `v6.0.2` | `de0fac2e4500…` |
| `build_documentation.yml` | `actions/setup-node` | `v6` | `v6` | `53b83947a5a9…` |
| `build_documentation.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `style_bot.yml` | `huggingface/huggingface_hub/.github/workflows/style-bot-action.yml` | `main` | `main` | `e000c1c89c65…` |
| `test_onnxruntime_slow.yml` | `jlumbroso/free-disk-space` | `main` | `main` | `54081f138730…` |
| `test_onnxruntime_slow.yml` | `actions/checkout` | `v5` | `v6.0.2` | `de0fac2e4500…` |
| `test_onnxruntime_slow.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#233