### PR TITLE
Add support for LightOn OCR models

### DIFF
--- a/optimum/exporters/onnx/__init__.py
+++ b/optimum/exporters/onnx/__init__.py
@@ -29,7 +29,11 @@ _import_structure = {
         "validate_models_outputs",
         "onnx_export_from_model",
     ],
-    "utils": ["MODEL_TYPES_REQUIRING_POSITION_IDS", "get_metaclip_2_models_for_export"],
+    "utils": [
+        "MODEL_TYPES_REQUIRING_POSITION_IDS",
+        "get_metaclip_2_models_for_export",
+        "get_lighton_ocr_models_for_export",
+    ],
     "__main__": ["main_export"],
 }
 
@@ -44,7 +48,11 @@ if TYPE_CHECKING:
         validate_model_outputs,
         validate_models_outputs,
     )
-    from optimum.exporters.onnx.utils import MODEL_TYPES_REQUIRING_POSITION_IDS, get_metaclip_2_models_for_export
+    from optimum.exporters.onnx.utils import (
+        MODEL_TYPES_REQUIRING_POSITION_IDS,
+        get_lighton_ocr_models_for_export,
+        get_metaclip_2_models_for_export,
+    )
 else:
     import sys
 

--- a/optimum/exporters/onnx/__main__.py
+++ b/optimum/exporters/onnx/__main__.py
@@ -360,6 +360,9 @@ def main_export(
         model_type = model.config.export_model_type
     else:
         model_type = model.config.model_type
+    from optimum.exporters.onnx.utils import is_lighton_ocr
+    if is_lighton_ocr(model.config):
+        model_type = "lighton_ocr"
 
     # ensure gpt_oss models dtype is float32 (dequantized to bf16 by default leading to incompatible dtypes)
     if is_mxfp4 and model_type == "gpt_oss":

--- a/optimum/exporters/onnx/convert.py
+++ b/optimum/exporters/onnx/convert.py
@@ -1019,6 +1019,10 @@ def onnx_export_from_model(
     else:
         model_type = model.config.model_type
 
+    from optimum.exporters.onnx.utils import is_lighton_ocr
+    if is_lighton_ocr(model.config):
+        model_type = "lighton_ocr"
+
     library_name = TasksManager.infer_library_from_model(model)
 
     custom_architecture = library_name == "transformers" and model_type not in TasksManager._SUPPORTED_MODEL_TYPE

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -789,36 +789,8 @@ class LightonOcrOnnxConfig(OnnxConfig):
             import os
 
             import onnx
-            from optimum.onnx import graph_transformations, merge_decoders
+            from optimum.onnx import merge_decoders
 
-            _original_check_and_save = graph_transformations.check_and_save_model
-
-            def _large_model_check_and_save(model, save_path):
-                save_path = _Path(save_path).as_posix()
-                external_file_name = os.path.basename(save_path) + "_data"
-                external_file_path = os.path.join(os.path.dirname(save_path), external_file_name)
-
-                if save_path.endswith(".onnx") and os.path.isfile(save_path):
-                    os.remove(save_path)
-                if os.path.isfile(external_file_path):
-                    os.remove(external_file_path)
-
-                onnx.save(
-                    model,
-                    save_path,
-                    save_as_external_data=True,
-                    location=external_file_name,
-                    all_tensors_to_one_file=True,
-                    convert_attribute=True,
-                    size_threshold=100,
-                )
-                try:
-                    onnx.checker.check_model(save_path)
-                except Exception as e:
-                    if "No Op registered for" not in str(e):
-                        raise
-
-            graph_transformations.check_and_save_model = _large_model_check_and_save
             try:
                 merge_decoders(
                     decoder=decoder_path,
@@ -827,8 +799,6 @@ class LightonOcrOnnxConfig(OnnxConfig):
                 )
             except Exception as e:
                 raise RuntimeError("Unable to merge decoders") from e
-            finally:
-                graph_transformations.check_and_save_model = _original_check_and_save
 
             new_subpaths = []
             for sp in onnx_files_subpaths:

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -643,11 +643,10 @@ _register_lighton_ocr_in_transformers()
     library_name="transformers",
 )
 class LightonOcrOnnxConfig(OnnxConfig):
-
     NORMALIZED_CONFIG_CLASS = LightonOcrNormalizedConfig
     MIN_TRANSFORMERS_VERSION = version.parse("4.56.0")
     SUPPORTS_PAST = True
-    VARIANTS = {
+    VARIANTS = {  # noqa: RUF012
         "split": "Vision encoder, token embeddings, and decoder are exported as separate ONNX models.",
     }
     DEFAULT_VARIANT = "split"
@@ -781,7 +780,6 @@ class LightonOcrOnnxConfig(OnnxConfig):
             ONNX_DECODER_NAME,
             ONNX_DECODER_WITH_PAST_NAME,
         )
-
 
         decoder_path = _Path(path, ONNX_DECODER_NAME + ".onnx")
         decoder_with_past_path = _Path(path, ONNX_DECODER_WITH_PAST_NAME + ".onnx")

--- a/optimum/exporters/onnx/model_configs.py
+++ b/optimum/exporters/onnx/model_configs.py
@@ -44,6 +44,7 @@ from optimum.exporters.onnx.model_patcher import (
     CohereModelPatcher,
     FluxTransformerModelPatcher,
     GptOssModelPatcher,
+    LightonOcrModelPatcher,
     MetaCLIP2Patcher,
     MgpstrModelPatcher,
     MoonshineModelPatcher,
@@ -579,6 +580,351 @@ class MistralOnnxConfig(TextDecoderWithPositionIdsOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(num_key_value_heads="num_key_value_heads", allow_new=True)
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)
     DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
+
+
+class LightonOcrNormalizedConfig(NormalizedTextConfig):
+    """Normalized config for LightOn OCR that reads from the text_config sub-config."""
+
+    NUM_LAYERS = "text_config.num_hidden_layers"
+    NUM_ATTENTION_HEADS = "text_config.num_attention_heads"
+    NUM_KEY_VALUE_HEADS = "text_config.num_key_value_heads"
+    HIDDEN_SIZE = "text_config.hidden_size"
+    VOCAB_SIZE = "text_config.vocab_size"
+
+    def __init__(self, config):
+        super().__init__(config)
+        text_config = config.text_config if hasattr(config, "text_config") else config
+        self.hidden_size = text_config.hidden_size
+        self.num_attention_heads = text_config.num_attention_heads
+        self.num_key_value_heads = getattr(text_config, "num_key_value_heads", text_config.num_attention_heads)
+        self.num_layers = text_config.num_hidden_layers
+        self.vocab_size = text_config.vocab_size
+        self.head_dim = getattr(text_config, "head_dim", self.hidden_size // self.num_attention_heads)
+        if hasattr(config, "vision_config"):
+            self.vision_config = config.vision_config
+
+
+def _register_lighton_ocr_in_transformers():
+    from transformers import AutoConfig, AutoModelForImageTextToText, Mistral3Config, Mistral3ForConditionalGeneration
+
+    if "lighton_ocr" in getattr(AutoConfig, "_model_mapping", {}).get("model_type", {}).__class__.__dict__.get(
+        "_mapping", {}
+    ):
+        return
+
+    class LightonOcrConfig(Mistral3Config):
+        model_type = "lighton_ocr"
+
+    class LightonOcrForConditionalGeneration(Mistral3ForConditionalGeneration):
+        config_class = LightonOcrConfig
+        _checkpoint_conversion_mapping = {  # noqa: RUF012
+            "^model.vision_encoder.": "model.vision_tower.",
+            "^model.vision_projection.": "model.multi_modal_projector.",
+            "^model.language_model.lm_head.": "lm_head.",
+            "^model.language_model.model.": "model.language_model.",
+        }
+
+    LightonOcrConfig.__module__ = Mistral3Config.__module__
+    LightonOcrForConditionalGeneration.__module__ = Mistral3ForConditionalGeneration.__module__
+
+    try:
+        AutoConfig.register("lighton_ocr", LightonOcrConfig)
+        AutoModelForImageTextToText.register(LightonOcrConfig, LightonOcrForConditionalGeneration)
+    except Exception:
+        pass
+
+
+_register_lighton_ocr_in_transformers()
+
+
+@register_tasks_manager_onnx(
+    "lighton_ocr",
+    *["image-text-to-text", "image-text-to-text-with-past"],
+    library_name="transformers",
+)
+class LightonOcrOnnxConfig(OnnxConfig):
+
+    NORMALIZED_CONFIG_CLASS = LightonOcrNormalizedConfig
+    MIN_TRANSFORMERS_VERSION = version.parse("4.56.0")
+    SUPPORTS_PAST = True
+    VARIANTS = {
+        "split": "Vision encoder, token embeddings, and decoder are exported as separate ONNX models.",
+    }
+    DEFAULT_VARIANT = "split"
+    _MODEL_PATCHER = LightonOcrModelPatcher
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        task: str = "image-text-to-text",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        variant: str = "split",
+        component: str | None = None,
+        use_past: bool = False,
+        use_past_in_inputs: bool = False,
+        preprocessors: list[Any] | None = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self.variant = variant
+        self.component = component
+        self.use_past = use_past
+        self.use_past_in_inputs = use_past_in_inputs
+        self.is_merged = False
+        self.use_cache_branch = None
+
+    @property
+    def inputs(self) -> dict[str, dict[int, str]]:
+        if self.component == "vision_encoder":
+            return {
+                "pixel_values": {0: "batch_size", 1: "num_channels", 2: "height", 3: "width"},
+            }
+        elif self.component == "embed_tokens":
+            return {
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+            }
+        elif self.component == "decoder":
+            common_inputs = {
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length", 2: "hidden_size"},
+                "attention_mask": {0: "batch_size", 1: "past_sequence_length + sequence_length"},
+                "position_ids": {0: "batch_size", 1: "sequence_length"},
+            }
+            if self.use_past_in_inputs:
+                self._add_past_key_values(common_inputs, direction="inputs")
+            return common_inputs
+        return {}
+
+    @property
+    def outputs(self) -> dict[str, dict[int, str]]:
+        if self.component == "vision_encoder":
+            return {
+                "image_features": {0: "batch_size", 1: "num_image_tokens", 2: "hidden_size"},
+            }
+        elif self.component == "embed_tokens":
+            return {
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length", 2: "hidden_size"},
+            }
+        elif self.component == "decoder":
+            common_outputs = {"logits": {0: "batch_size", 1: "sequence_length"}}
+            self._add_past_key_values(common_outputs, direction="outputs")
+            return common_outputs
+        return {}
+
+    def _add_past_key_values(self, inputs_or_outputs: dict[str, dict[int, str]], direction: str):
+        text_config = self._config.text_config if hasattr(self._config, "text_config") else self._config
+        num_layers = text_config.num_hidden_layers
+
+        if direction == "inputs":
+            for i in range(num_layers):
+                inputs_or_outputs[f"past_key_values.{i}.key"] = {
+                    0: "batch_size",
+                    2: "past_sequence_length",
+                }
+                inputs_or_outputs[f"past_key_values.{i}.value"] = {
+                    0: "batch_size",
+                    2: "past_sequence_length",
+                }
+        else:
+            for i in range(num_layers):
+                inputs_or_outputs[f"present.{i}.key"] = {
+                    0: "batch_size",
+                    2: "past_sequence_length + sequence_length",
+                }
+                inputs_or_outputs[f"present.{i}.value"] = {
+                    0: "batch_size",
+                    2: "past_sequence_length + sequence_length",
+                }
+
+    def flatten_past_key_values(self, flattened_output, name, idx, t):
+        flattened_output[f"{name}.{idx}.key"] = t[0]
+        flattened_output[f"{name}.{idx}.value"] = t[1]
+
+    def flatten_output_collection_property(self, name: str, field) -> dict[str, Any]:
+        flattened_output = {}
+        if name in ["present", "past_key_values"]:
+            for idx, t in enumerate(field):
+                self.flatten_past_key_values(flattened_output, name, idx, t)
+        else:
+            flattened_output = super().flatten_output_collection_property(name, field)
+        return flattened_output
+
+    def _generate_dummy_inputs_for_validation_inner(
+        self, reference_model_inputs: dict[str, Any], onnx_input_names: list[str]
+    ) -> dict[str, Any]:
+        if self.component != "decoder":
+            return reference_model_inputs
+        filtered = {}
+        for name, value in reference_model_inputs.items():
+            if name == "past_key_values":
+                if any(n.startswith("past_key_values.") for n in onnx_input_names):
+                    filtered[name] = value
+            else:
+                filtered[name] = value
+        return filtered
+
+    def post_process_exported_models(
+        self,
+        path,
+        models_and_onnx_configs,
+        onnx_files_subpaths,
+    ):
+        from pathlib import Path as _Path
+
+        from optimum.exporters.onnx.constants import (
+            ONNX_DECODER_MERGED_NAME,
+            ONNX_DECODER_NAME,
+            ONNX_DECODER_WITH_PAST_NAME,
+        )
+
+
+        decoder_path = _Path(path, ONNX_DECODER_NAME + ".onnx")
+        decoder_with_past_path = _Path(path, ONNX_DECODER_WITH_PAST_NAME + ".onnx")
+        decoder_merged_path = _Path(path, ONNX_DECODER_MERGED_NAME + ".onnx")
+
+        if decoder_path.is_file() and decoder_with_past_path.is_file():
+            import os
+
+            import onnx
+            from optimum.onnx import graph_transformations, merge_decoders
+
+            _original_check_and_save = graph_transformations.check_and_save_model
+
+            def _large_model_check_and_save(model, save_path):
+                save_path = _Path(save_path).as_posix()
+                external_file_name = os.path.basename(save_path) + "_data"
+                external_file_path = os.path.join(os.path.dirname(save_path), external_file_name)
+
+                if save_path.endswith(".onnx") and os.path.isfile(save_path):
+                    os.remove(save_path)
+                if os.path.isfile(external_file_path):
+                    os.remove(external_file_path)
+
+                onnx.save(
+                    model,
+                    save_path,
+                    save_as_external_data=True,
+                    location=external_file_name,
+                    all_tensors_to_one_file=True,
+                    convert_attribute=True,
+                    size_threshold=100,
+                )
+                try:
+                    onnx.checker.check_model(save_path)
+                except Exception as e:
+                    if "No Op registered for" not in str(e):
+                        raise
+
+            graph_transformations.check_and_save_model = _large_model_check_and_save
+            try:
+                merge_decoders(
+                    decoder=decoder_path,
+                    decoder_with_past=decoder_with_past_path,
+                    save_path=decoder_merged_path,
+                )
+            except Exception as e:
+                raise RuntimeError("Unable to merge decoders") from e
+            finally:
+                graph_transformations.check_and_save_model = _original_check_and_save
+
+            new_subpaths = []
+            for sp in onnx_files_subpaths:
+                if sp in [ONNX_DECODER_NAME + ".onnx", ONNX_DECODER_WITH_PAST_NAME + ".onnx"]:
+                    new_subpaths.append(decoder_merged_path.name)
+                else:
+                    new_subpaths.append(sp)
+            onnx_files_subpaths = new_subpaths
+
+            models_and_onnx_configs[ONNX_DECODER_NAME][1].is_merged = True
+            models_and_onnx_configs[ONNX_DECODER_NAME][1].use_cache_branch = False
+            models_and_onnx_configs[ONNX_DECODER_NAME][1].use_past_in_inputs = True
+
+            models_and_onnx_configs[ONNX_DECODER_WITH_PAST_NAME][1].use_cache_branch = True
+            models_and_onnx_configs[ONNX_DECODER_WITH_PAST_NAME][1].is_merged = True
+
+            for p in [decoder_path, decoder_with_past_path]:
+                if p.is_file():
+                    p.unlink()
+                ext_data = _Path(str(p) + "_data")
+                if ext_data.is_file():
+                    ext_data.unlink()
+
+        return models_and_onnx_configs, onnx_files_subpaths
+
+    def generate_dummy_inputs(self, framework="pt", **input_shapes):
+        import torch
+
+        batch_size = input_shapes.get("batch_size", 2)
+        seq_length = input_shapes.get("sequence_length", 16)
+        text_config = self._config.text_config if hasattr(self._config, "text_config") else self._config
+        vision_config = getattr(self._config, "vision_config", None)
+
+        if self.component == "vision_encoder":
+            num_channels = getattr(vision_config, "num_channels", 3)
+            image_size = 56
+            return {
+                "pixel_values": torch.randn(1, num_channels, image_size, image_size),
+            }
+        elif self.component == "embed_tokens":
+            return {
+                "input_ids": torch.randint(0, text_config.vocab_size, (batch_size, seq_length)),
+            }
+        elif self.component == "decoder":
+            hidden_size = text_config.hidden_size
+            num_layers = text_config.num_hidden_layers
+            num_kv_heads = getattr(text_config, "num_key_value_heads", text_config.num_attention_heads)
+            head_dim = getattr(text_config, "head_dim", hidden_size // text_config.num_attention_heads)
+
+            dummy = {
+                "inputs_embeds": torch.randn(batch_size, seq_length, hidden_size),
+                "position_ids": torch.arange(seq_length, dtype=torch.long).unsqueeze(0).expand(batch_size, -1),
+            }
+
+            if self.use_past_in_inputs:
+                past_seq_length = input_shapes.get("past_sequence_length", 16)
+                dummy["attention_mask"] = torch.ones(batch_size, past_seq_length + seq_length, dtype=torch.long)
+                dummy["past_key_values"] = tuple(
+                    (
+                        torch.randn(batch_size, num_kv_heads, past_seq_length, head_dim),
+                        torch.randn(batch_size, num_kv_heads, past_seq_length, head_dim),
+                    )
+                    for i in range(num_layers)
+                )
+            else:
+                dummy["attention_mask"] = torch.ones(batch_size, seq_length, dtype=torch.long)
+
+            return dummy
+        return {}
+
+    def generate_dummy_inputs_for_validation(
+        self, reference_model_inputs: dict[str, Any], onnx_input_names: list[str]
+    ) -> dict[str, Any]:
+        import torch
+
+        if self.is_merged is True and self.use_cache_branch is not None:
+            reference_model_inputs["use_cache_branch"] = torch.tensor([self.use_cache_branch], dtype=torch.bool)
+
+            if self.use_cache_branch is False:
+                text_config = self._config.text_config if hasattr(self._config, "text_config") else self._config
+                num_layers = text_config.num_hidden_layers
+                num_kv_heads = getattr(text_config, "num_key_value_heads", text_config.num_attention_heads)
+                hidden_size = text_config.hidden_size
+                head_dim = getattr(text_config, "head_dim", hidden_size // text_config.num_attention_heads)
+                batch_size = reference_model_inputs["inputs_embeds"].shape[0]
+                reference_model_inputs["past_key_values"] = tuple(
+                    (
+                        torch.zeros(batch_size, num_kv_heads, 1, head_dim),
+                        torch.zeros(batch_size, num_kv_heads, 1, head_dim),
+                    )
+                    for _ in range(num_layers)
+                )
+
+        return self._generate_dummy_inputs_for_validation_inner(reference_model_inputs, onnx_input_names)
 
 
 @register_tasks_manager_onnx("mpt", *[*COMMON_TEXT_GENERATION_TASKS, "text-classification", "token-classification"])

--- a/optimum/exporters/onnx/model_patcher.py
+++ b/optimum/exporters/onnx/model_patcher.py
@@ -1459,3 +1459,125 @@ class GptOssModelPatcher(ModelPatcher):
 
         if is_transformers_version(">=", "4.55.0"):
             GptOssExperts.forward = self.original_gpt_oss_forward
+
+
+class LightonOcrModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: OnnxConfig,
+        model: PreTrainedModel,
+        model_kwargs: dict[str, Any] | None = None,
+    ):
+        super().__init__(config, model, model_kwargs)
+        self._export_config = config
+
+        orig_sig = inspect.signature(self.orig_forward)
+        orig_param_names = list(orig_sig.parameters.keys())
+
+        @functools.wraps(self.orig_forward)
+        def patched_forward(*args, **kwargs):
+            for i, val in enumerate(args):
+                if i < len(orig_param_names):
+                    kwargs[orig_param_names[i]] = val
+
+            pixel_values = kwargs.get("pixel_values")
+            input_ids = kwargs.get("input_ids")
+            inputs_embeds = kwargs.get("inputs_embeds")
+            attention_mask = kwargs.get("attention_mask")
+            position_ids = kwargs.get("position_ids")
+            past_key_values = kwargs.get("past_key_values")
+            if config.component == "vision_encoder":
+                vision_tower = model.model.vision_tower
+                projector = model.model.multi_modal_projector
+
+                patch_size = vision_tower.patch_size
+                spatial_merge_size = projector.patch_merger.spatial_merge_size
+
+                patch_embeds = vision_tower.patch_conv(pixel_values)
+                h_patches = patch_embeds.shape[2]
+                w_patches = patch_embeds.shape[3]
+
+                patch_embeds_flat = patch_embeds[0].flatten(1).T.unsqueeze(0)
+                patch_embeds_flat = vision_tower.ln_pre(patch_embeds_flat)
+
+                max_width = vision_tower.config.image_size // patch_size
+                spatial = patch_embeds[0, 0]
+                row_ids = torch.ones_like(spatial).cumsum(dim=0) - 1
+                col_ids = torch.ones_like(spatial).cumsum(dim=1) - 1
+                position_ids_vis = (row_ids * max_width + col_ids).reshape(-1).long()
+
+                position_embeddings = vision_tower.patch_positional_embedding(patch_embeds_flat, position_ids_vis)
+
+                transformer_output = vision_tower.transformer(
+                    patch_embeds_flat,
+                    attention_mask=None,
+                    position_embeddings=position_embeddings,
+                    output_hidden_states=False,
+                    output_attentions=False,
+                    return_dict=True,
+                )
+                image_features = transformer_output[0].squeeze(0)
+
+                image_features = projector.norm(image_features)
+
+                d = image_features.shape[-1]
+                image_grid = image_features.view(h_patches, w_patches, d).permute(2, 0, 1).unsqueeze(0)
+                grid = torch.nn.functional.unfold(
+                    image_grid, kernel_size=spatial_merge_size, stride=spatial_merge_size
+                )
+                grid = grid.view(d * spatial_merge_size**2, -1).t()
+                image_features = projector.patch_merger.merging_layer(grid)
+
+                image_features = projector.linear_1(image_features)
+                image_features = projector.act(image_features)
+                image_features = projector.linear_2(image_features)
+
+                return {"image_features": image_features.unsqueeze(0)}
+
+            elif config.component == "embed_tokens":
+                embeds = model.model.language_model.embed_tokens(input_ids)
+                return {"inputs_embeds": embeds}
+
+            elif config.component == "decoder":
+                hidden_states = inputs_embeds
+                language_model = model.model.language_model
+
+                cache = None
+                if past_key_values is not None:
+                    cache = DynamicCache()
+                    for i, (k, v) in enumerate(past_key_values):
+                        cache.update(k, v, layer_idx=i)
+
+                lm_outputs = language_model(
+                    inputs_embeds=hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_values=cache,
+                    use_cache=True,
+                    return_dict=True,
+                )
+
+                hidden_states = lm_outputs.last_hidden_state
+                logits = model.lm_head(hidden_states)
+
+                result = {"logits": logits}
+                out_cache = lm_outputs.past_key_values
+                num_layers = len(language_model.layers)
+                for i in range(num_layers):
+                    key, value = out_cache[i]
+                    result[f"present.{i}.key"] = key
+                    result[f"present.{i}.value"] = value
+                return result
+
+        self.patched_forward = patched_forward
+
+    def __enter__(self):
+        if self._export_config.component == "vision_encoder":
+            self._orig_attn_impl = self._model.model.vision_tower.config._attn_implementation
+            self._model.model.vision_tower.config._attn_implementation = "eager"
+        super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if hasattr(self, "_orig_attn_impl"):
+            self._model.model.vision_tower.config._attn_implementation = self._orig_attn_impl

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -167,6 +167,41 @@ def get_metaclip_2_models_for_export(model: PreTrainedModel, config: ExporterCon
     return models_for_export
 
 
+def get_lighton_ocr_models_for_export(model: PreTrainedModel, config: ExporterConfig):
+    """Create the 4-part split for LightOn OCR: vision_encoder, embed_tokens, decoder, decoder_with_past."""
+    models_for_export = {}
+
+    vision_encoder_config = config.__class__(
+        model.config, task=config.task, variant=config.variant, component="vision_encoder"
+    )
+    embed_tokens_config = config.__class__(
+        model.config, task=config.task, variant=config.variant, component="embed_tokens"
+    )
+    decoder_config = config.__class__(
+        model.config,
+        task=config.task,
+        variant=config.variant,
+        component="decoder",
+        use_past=True,
+        use_past_in_inputs=False,
+    )
+    decoder_with_past_config = config.__class__(
+        model.config,
+        task=config.task,
+        variant=config.variant,
+        component="decoder",
+        use_past=True,
+        use_past_in_inputs=True,
+    )
+
+    models_for_export["vision_encoder"] = (model, vision_encoder_config)
+    models_for_export["embed_tokens"] = (model, embed_tokens_config)
+    models_for_export["decoder_model"] = (model, decoder_config)
+    models_for_export["decoder_with_past_model"] = (model, decoder_with_past_config)
+
+    return models_for_export
+
+
 def get_sana_models_for_export(pipeline: DiffusionPipeline, int_dtype: str = "int64", float_dtype: str = "fp32"):
     import copy
 
@@ -260,6 +295,19 @@ def _get_submodels_and_onnx_configs(
         )
         export_config.variant = _variant
         return export_config, get_metaclip_2_models_for_export(model, export_config)
+
+    if library_name == "transformers" and model.config.model_type == "lighton_ocr":
+        export_config_constructor = TasksManager.get_exporter_config_constructor(
+            model=model, exporter="onnx", task=task, library_name="transformers", model_type="lighton_ocr"
+        )
+        export_config = export_config_constructor(
+            model.config,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        export_config.variant = _variant
+        return export_config, get_lighton_ocr_models_for_export(model, export_config)
 
     if library_name == "diffusers" and model.__class__.__name__.startswith("Sana"):
         return None, get_sana_models_for_export(model, int_dtype, float_dtype)

--- a/optimum/exporters/onnx/utils.py
+++ b/optimum/exporters/onnx/utils.py
@@ -167,6 +167,13 @@ def get_metaclip_2_models_for_export(model: PreTrainedModel, config: ExporterCon
     return models_for_export
 
 
+def is_lighton_ocr(config):
+    arch = getattr(config, "architectures", [])
+    if "LightOnOCRForConditionalGeneration" in arch:
+        return True
+    return getattr(config, "model_type", None) == "lighton_ocr"
+
+
 def get_lighton_ocr_models_for_export(model: PreTrainedModel, config: ExporterConfig):
     """Create the 4-part split for LightOn OCR: vision_encoder, embed_tokens, decoder, decoder_with_past."""
     models_for_export = {}
@@ -296,7 +303,7 @@ def _get_submodels_and_onnx_configs(
         export_config.variant = _variant
         return export_config, get_metaclip_2_models_for_export(model, export_config)
 
-    if library_name == "transformers" and model.config.model_type == "lighton_ocr":
+    if library_name == "transformers" and is_lighton_ocr(model.config):
         export_config_constructor = TasksManager.get_exporter_config_constructor(
             model=model, exporter="onnx", task=task, library_name="transformers", model_type="lighton_ocr"
         )

--- a/optimum/onnx/graph_transformations.py
+++ b/optimum/onnx/graph_transformations.py
@@ -134,7 +134,12 @@ def check_and_save_model(model: onnx.ModelProto, save_path: str | Path | None):
     # For larger models, we need to save them first and then check their save path.
     # https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md#checking-a-large-onnx-model-2gb
 
-    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+    try:
+        model_size = model.ByteSize()
+    except Exception:
+        model_size = onnx.checker.MAXIMUM_PROTOBUF + 1
+
+    if model_size < onnx.checker.MAXIMUM_PROTOBUF:
         # For the try catch, refer to https://github.com/microsoft/onnxruntime/issues/14768
         try:
             onnx.checker.check_model(model)
@@ -157,8 +162,9 @@ def check_and_save_model(model: onnx.ModelProto, save_path: str | Path | None):
         os.remove(external_file_path)
 
     FORCE_ONNX_EXTERNAL_DATA = os.getenv("FORCE_ONNX_EXTERNAL_DATA", "0") == "1"  # noqa: N806
+    is_too_large = model_size >= onnx.checker.MAXIMUM_PROTOBUF
 
-    if model_uses_external_data or FORCE_ONNX_EXTERNAL_DATA:
+    if model_uses_external_data or FORCE_ONNX_EXTERNAL_DATA or is_too_large:
         onnx.save(
             model,
             save_path,

--- a/tests/exporters/onnx/utils_tests.py
+++ b/tests/exporters/onnx/utils_tests.py
@@ -130,6 +130,7 @@ PYTORCH_EXPORT_MODELS_TINY = {
     "layoutlm": "hf-internal-testing/tiny-random-LayoutLMModel",
     "layoutlmv3": "hf-internal-testing/tiny-random-LayoutLMv3Model",
     "lilt": "hf-internal-testing/tiny-random-LiltModel",
+    "lighton_ocr": "Remidesbois/tiny-random-LightOnOCR",
     "llama": "fxmarty/tiny-llama-fast-tokenizer",
     "longt5": "fxmarty/tiny-random-working-LongT5Model",
     "longformer": "hf-internal-testing/tiny-random-LongformerModel",


### PR DESCRIPTION
Registers lighton_ocr as a model type and exports it as three ONNX files with data files:
- vision_encoder
- embed_tokens
- decoder_model_merged

Handles weight key remapping from lighton_ocr to Mistral3 internals.
Works around the >2GB protobuf limit during decoder merge.